### PR TITLE
TAO-392: Display lock on read-only resources in tree

### DIFF
--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -74,8 +74,8 @@ class taoTests_actions_Tests extends tao_actions_SaSModule {
      * or table with list of test properties {@see self::viewTest()}
      * depending on user rights. 
      * If the user does not have WIRTE and READ access then PermissionException will be thrown.
-     * 
      * @throws PermissionException
+     * @requiresRight id READ
      */
     public function getTest()
     {
@@ -181,6 +181,7 @@ class taoTests_actions_Tests extends tao_actions_SaSModule {
 
 	/**
 	 * Redirect the test's authoring
+         * @requiresRight id READ
 	 */
 	public function authoring()
 	{

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -153,6 +153,16 @@ class taoTests_actions_Tests extends tao_actions_SaSModule {
         $this->setData('model', $this->service->getTestModel($test)->getLabel());
         $this->setView('view_test.tpl');
     }
+    
+    /**
+     * Move an instance from a class to another
+     * @return void
+     * @requiresRight uri READ
+     */
+    public function moveInstance()
+    {
+        parent::moveInstance();
+    }
         
     /**
      * delete a test or a test class

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -20,6 +20,9 @@
  * 
  */
 
+use oat\tao\model\accessControl\AclProxy;
+use oat\tao\model\accessControl\data\PermissionException;
+
 /**
  * Tests Controller provide actions performed from url resolution
  *
@@ -66,59 +69,91 @@ class taoTests_actions_Tests extends tao_actions_SaSModule {
  * controller actions
  */
 
+    /**
+     * Action renders form for editing test {@see self::editTest()} 
+     * or table with list of test properties {@see self::viewTest()}
+     * depending on user rights. 
+     * If the user does not have WIRTE and READ access then PermissionException will be thrown.
+     * 
+     * @throws PermissionException
+     */
+    public function getTest()
+    {
+        $test = $this->getCurrentInstance();
+        $user = common_Session_SessionManager::getSession()->getUser();
+        $testId = $test->getUri();
+        
+        if (AclProxy::hasAccess($user, __CLASS__, 'editTest', array('id'=>$testId))) {
+            $this->editTest();
+        } elseif (AclProxy::hasAccess($user, __CLASS__, 'viewTest', array('id'=>$testId)))  {
+            $this->viewTest();
+        } else {
+            throw new PermissionException($user->getIdentifier(), 'getTest', __CLASS__, 'taoTest');
+        }
+    }
+        
+    /**
+     * Action renders form for editing test.
+     * @requiresRight id WRITE
+     */
+    public function editTest()
+    {
+        $clazz = $this->getCurrentClass();
+        $test = $this->getCurrentInstance();
+        $testModel = $this->service->getTestModel($test) ?: null;
+        
+        $formContainer = new tao_actions_form_Instance($clazz, $test);
+        $myForm = $formContainer->getForm();
+        if ($myForm->isSubmited() && $myForm->isValid()) {
+            $propertyValues = $myForm->getValues();
 
-	/**
-	 * edit a test instance
-	 * @requiresRight id READ
-	 */
-	public function editTest()
-	{
-		$clazz = $this->getCurrentClass();
-		$test = $this->getCurrentInstance();
-		$testModel = $this->service->getTestModel($test);
-		// workaround because of bug:
-		$testModel = $testModel == '' ? null : $testModel;
+            // don't hande the testmodel via bindProperties
+            if (array_key_exists(PROPERTY_TEST_TESTMODEL, $propertyValues)) {
+                $modelUri = $propertyValues[PROPERTY_TEST_TESTMODEL];
+                unset($propertyValues[PROPERTY_TEST_TESTMODEL]);
+                if (!empty($modelUri)) {
+                    $testModel = new core_kernel_classes_Resource($modelUri);
+                    $this->service->setTestModel($test, $testModel);
+                }
+            } else {
+                common_Logger::w('No testmodel on test form', 'taoTests');
+            }
 
-		$formContainer = new tao_actions_form_Instance($clazz, $test);
-		$myForm = $formContainer->getForm();
-		if($myForm->isSubmited()){
-			if($myForm->isValid()){
-				$propertyValues = $myForm->getValues();
+            //then save the property values as usual
+            $binder = new tao_models_classes_dataBinding_GenerisFormDataBinder($test);
+            $test = $binder->bind($propertyValues);
 
-				// don't hande the testmodel via bindProperties
-				if(array_key_exists(PROPERTY_TEST_TESTMODEL, $propertyValues)){
-					$modelUri = $propertyValues[PROPERTY_TEST_TESTMODEL];
-					unset($propertyValues[PROPERTY_TEST_TESTMODEL]);
-					if (!empty($modelUri)) {
-						$testModel = new core_kernel_classes_Resource($modelUri);
-						$this->service->setTestModel($test, $testModel);
-					}
-				} else {
-					common_Logger::w('No testmodel on test form', 'taoTests');
-				}
+            //edit process label:
+            $this->service->onChangeTestLabel($test);
 
-				//then save the property values as usual
-				$binder = new tao_models_classes_dataBinding_GenerisFormDataBinder($test);
-				$test = $binder->bind($propertyValues);
+            $this->setData("selectNode", tao_helpers_Uri::encode($test->getUri()));
+            $this->setData('message', __('Test saved'));
+            $this->setData('reload', true);
+        }
 
-				//edit process label:
-				$this->service->onChangeTestLabel($test);
+        $myForm->removeElement(tao_helpers_Uri::encode(TEST_TESTCONTENT_PROP));
 
-		        $this->setData("selectNode", tao_helpers_Uri::encode($test->getUri()));
-				$this->setData('message', __('Test saved'));
-				$this->setData('reload', true);
-			}
-		}
-
-		$myForm->removeElement(tao_helpers_Uri::encode(TEST_TESTCONTENT_PROP));
-
-		$this->setData('uri', tao_helpers_Uri::encode($test->getUri()));
-		$this->setData('classUri', tao_helpers_Uri::encode($clazz->getUri()));
-		$this->setData('formTitle', __('Test properties'));
-		$this->setData('myForm', $myForm->render());
-		$this->setView('form_test.tpl');
-	}
-
+        $this->setData('uri', tao_helpers_Uri::encode($test->getUri()));
+        $this->setData('classUri', tao_helpers_Uri::encode($clazz->getUri()));
+        $this->setData('formTitle', __('Test properties'));
+        $this->setData('myForm', $myForm->render());
+        $this->setView('form_test.tpl');
+    }
+    
+    
+    /**
+     * Action renders table with list of test properties.
+     * @requiresRight id READ
+     */    
+    public function viewTest()
+    {
+        $test = $this->getCurrentInstance();
+        
+        $this->setData('label', $test->getLabel());
+        $this->setData('model', $this->service->getTestModel($test)->getLabel());
+        $this->setView('view_test.tpl');
+    }
+        
 	/**
 	 * delete a test or a test class
 	 * called via ajax

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -154,10 +154,10 @@ class taoTests_actions_Tests extends tao_actions_SaSModule {
         $this->setView('view_test.tpl');
     }
         
-	/**
-	 * delete a test or a test class
-	 * called via ajax
-	 * @return void
+    /**
+     * delete a test or a test class
+     * called via ajax
+     * @return void
      * @throws Exception
      */
     public function delete()

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -13,18 +13,21 @@
                           selectClass="test-class-properties"
                           selectInstance="test-properties"
                           moveInstance="test-move"
+                          editInstance="test-edit"
+                          viewInstance="test-view"
                           delete="test-delete"
                           rootNode="http://www.tao.lu/Ontologies/TAOTest.rdf#Test"
-                        />
+                    />
                 </trees>
                 <actions>
-                	
-                	<action id="test-class-properties" name="Properties" url="/taoTests/Tests/editClassProperties" group="content" context="class">
+                    <action id="test-class-properties" name="Properties" url="/taoTests/Tests/editClassProperties" group="content" context="class">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-properties"  name="Properties"  url="/taoTests/Tests/editTest" group="content" context="instance">
+                    <action id="test-properties" name="Properties" url="/taoTests/Tests/getTest" group="content" context="instance">
                         <icon id="icon-edit"/>
                     </action>
+                    <action id="test-edit" name="Edit" url="/taoTests/Tests/editTest" group="none" context="instance"></action>
+                    <action id="test-view" name="View" url="/taoTests/Tests/viewTest" group="none" context="instance"></action>
                     <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor">
                         <icon id="icon-edit"/>
                     </action>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -11,11 +11,9 @@
                           className="Test"
                           dataUrl="/taoTests/Tests/getOntologyData"
                           selectClass="test-class-properties"
-                          selectInstance="test-properties"
-                          moveInstance="test-move"
                           editInstance="test-edit"
                           viewInstance="test-view"
-                          delete="test-delete"
+                          moveInstance="test-move"
                           rootNode="http://www.tao.lu/Ontologies/TAOTest.rdf#Test"
                     />
                 </trees>
@@ -26,8 +24,12 @@
                     <action id="test-properties" name="Properties" url="/taoTests/Tests/getTest" group="content" context="instance">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-edit" name="Edit" url="/taoTests/Tests/editTest" group="none" context="instance"></action>
-                    <action id="test-view" name="View" url="/taoTests/Tests/viewTest" group="none" context="instance"></action>
+                    <action id="test-edit" name="Edit" url="/taoTests/Tests/editTest" group="none" context="instance">
+                        <icon id="icon-edit"/>
+                    </action>
+                    <action id="test-view" name="View" url="/taoTests/Tests/viewTest" group="none" context="instance">
+                        <icon id="icon-preview"/>
+                    </action>
                     <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor">
                         <icon id="icon-edit"/>
                     </action>

--- a/views/templates/view_test.tpl
+++ b/views/templates/view_test.tpl
@@ -1,0 +1,33 @@
+<?php
+use oat\tao\helpers\Template;
+Template::inc('form_context.tpl', 'tao');
+?>
+
+<header class="section-header flex-container-full">
+    <h2><?= get_data('label') ?></h2>
+</header>
+
+<div class="main-container flex-container-main-form">
+    <div class="form-content">
+        <div class="xhtml_form">
+            <form>
+                <div class="property-container">
+                    <div class="form-group property-block-first property-block readonly-property">
+                        <span class="property-heading-label"><?=__('Label')?></span>
+                        <div>
+                            <div><?= get_data('label') ?></div>
+                        </div>
+                    </div>
+                    <div class="form-group property-block readonly-property">
+                        <span class="property-heading-label"><?=__('Test Model')?></span>
+                        <div>
+                            <div><?= get_data('model') ?></div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<?php Template::inc('footer.tpl', 'tao'); ?>


### PR DESCRIPTION
Action `taoTests_actions_Tests::getTest()` decides which action execute (`editTest` or `viewTest`) depending on user rights.