### PR TITLE
test pack model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,66 +1,61 @@
 {
-     "repositories": [
-      {
-		"type": "vcs",
-		"url": "git@github.com:oat-sa/oatbox-extension-installer.git"
-		}
-     ],
+    "repositories": [{
+        "type": "vcs",
+        "url": "git@github.com:oat-sa/oatbox-extension-installer.git"
+    }],
 
     "name": "oat-sa/extension-tao-test",
-    "authors" : [
-	{
-		"name" : "Open Assessment Technologies S.A.",
-		"homepage" : "http://www.taotesting.com"
-	},
-	{
-		"name": "Jérôme Bogaerts",
-		"role": "Developer"
-	},
-	{
-		"name": "Joel Bout",
-		"role": "Developer"
-	},
-	{
-		"name": "Bertrand Chevrier",
-		"role": "Developer"
-	},
-	{
-		"name": "Lionel Lecaque",
-		"role": "Developer"
-	},
-	{
-		"name": "Patrick Plichart",
-		"role": "Developer"
-	},
-	{
-		"name": "Dieter Raber",
-		"role": "Developer"
-	},
-	{
-		"name": "Somsack Sipasseuth",
-		"role": "Developer"
-	}
-    ],
-    "description" : "extension to manage tests",
+    "authors": [{
+        "name": "Open Assessment Technologies S.A.",
+        "homepage": "http://www.taotesting.com"
+    }, {
+        "name": "Jérôme Bogaerts",
+        "role": "Developer"
+    }, {
+        "name": "Joel Bout",
+        "role": "Developer"
+    }, {
+        "name": "Bertrand Chevrier",
+        "role": "Developer"
+    }, {
+        "name": "Lionel Lecaque",
+        "role": "Developer"
+    }, {
+        "name": "Patrick Plichart",
+        "role": "Developer"
+    }, {
+        "name": "Dieter Raber",
+        "role": "Developer"
+    }, {
+        "name": "Somsack Sipasseuth",
+        "role": "Developer"
+    }],
+    "description": "extension to manage tests",
     "support": {
-	"forum": "http://forum.taotesting.com",
-	"issues": "http://forge.taotesting.com"
+        "forum": "http://forum.taotesting.com",
+        "issues": "http://forge.taotesting.com"
     },
-    "homepage" : "http://www.taotesting.com",
-    "license" : [
-	"GPL-2.0"
-	],
-    "keywords" : [
-	"tao",
-	"oat",
-	"computer-based-assessment"
-	],
-    "type" : "tao-extension",
-    "extra" : {
-    	"tao-extension-name" : "taoTests"
+    "homepage": "http://www.taotesting.com",
+    "license": [
+        "GPL-2.0"
+    ],
+    "keywords": [
+        "tao",
+        "oat",
+        "computer-based-assessment"
+    ],
+    "type": "tao-extension",
+    "extra": {
+        "tao-extension-name": "taoTests"
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "dev-master"
 
+    },
+    "autoload": {
+        "psr-4": {
+            "oat\\taoTests\\models\\": "models/classes/",
+            "oat\\taoTests\\test\\": "test"
+        }
     }
 }

--- a/models/classes/interface.TestModel.php
+++ b/models/classes/interface.TestModel.php
@@ -1,22 +1,22 @@
 <?php
-/*  
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- * 
+ *
  */
 
 
@@ -26,7 +26,7 @@
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
  * @package taoItems
- 
+
  */
 interface taoTests_models_classes_TestModel
 {
@@ -42,38 +42,38 @@ interface taoTests_models_classes_TestModel
 
     /**
      * Called when the label of a test changes
-     * 
+     *
      * @param Resource $test
      */
     public function onChangeTestLabel( core_kernel_classes_Resource $test);
-    
+
     /**
      * Prepare the content of the test,
      * using the provided items if possible
-     * 
+     *
      * @param core_kernel_classes_Resource $test
      * @param array $items an array of item resources
      */
     public function prepareContent( core_kernel_classes_Resource $test, $items = array());
-    
+
     /**
      * Delete the content of the test
-     * 
+     *
      * @param Resource $test
      */
     public function deleteContent( core_kernel_classes_Resource $test);
-    
+
     /**
      * Returns all the items potenially used within the test
-     * 
+     *
      * @param Resource $test
      * @return array an array of item resources
      */
     public function getItems( core_kernel_classes_Resource $test);
-    
+
     /**
      * returns the test authoring url
-     * 
+     *
      * @param core_kernel_classes_Resource $test the test instance
      * @return string the authoring url
      */
@@ -82,18 +82,28 @@ interface taoTests_models_classes_TestModel
     /**
      * Clones the content of one test to another test,
      * assumes that other test has already been cleaned (using deleteContent())
-     * 
+     *
      * @access public
      * @author Joel Bout, <joel@taotesting.com>
      * @param core_kernel_classes_Resource $source
      * @param core_kernel_classes_Resource $destination
      */
     public function cloneContent( core_kernel_classes_Resource $source, core_kernel_classes_Resource $destination);
-    
+
     /**
      * Returns the compiler class of the test
-     * 
+     *
      * @return string
      */
     public function getCompilerClass();
+
+	/**
+	 * Return the Packable implementation for the given test model.
+     * Packing is an alternative to Compilation. A Packer generates the
+     * data needed to run a test where the compiler creates a stand alone
+     * test.
+	 *
+	 * @return oat\taoTests\model\pack\Packable the packer class to instantiate
+	 */
+    public function getPackerClass();
 }

--- a/models/classes/pack/Packable.php
+++ b/models/classes/pack/Packable.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoTests\models\pack;
+
+use \core_kernel_classes_Resource;
+use oat\taoTests\models\pack\TestPack;
+
+/**
+ * To allow packing of test. The goal of the packing is to reprensent the data needed
+ * to run an test (ie. an TestPack).
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+interface Packable
+{
+    /**
+     * Create a pack for an item.
+     *
+     * @param core_kernel_classes_Resource $test the test to pack
+     * @return TestPack
+     */
+    public function packTest(core_kernel_classes_Resource $test);
+}

--- a/models/classes/pack/Packer.php
+++ b/models/classes/pack/Packer.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoTests\models\pack;
+
+use \core_kernel_classes_Resource;
+use \taoTests_models_classes_TestsService;
+use \common_exception_NoImplementation;
+use \ReflectionClass;
+use \ReflectionException;
+use \common_Exception;
+use \Exception;
+
+/**
+ * The Test Packer calls the packable class for the given test
+ *
+ * @package taoTests
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class Packer
+{
+
+    /**
+     * The test to pack
+     * @var core_kernel_classes_Resource
+     */
+    private $test;
+
+
+    /**
+     * The test service
+     * @var taoTests_models_classes_TestService
+     */
+    private $testService;
+
+    /**
+     * Create a packer for a test
+     * @param core_kernel_classes_Resource $test
+     */
+    public function __construct(core_kernel_classes_Resource $test){
+        $this->test = $test;
+        $this->testService = taoTests_models_classes_TestsService::singleton();
+    }
+
+    /**
+     * Get the packer for the test regarding it's implementation.
+     *
+     * @return Packable the test packer implementation
+     * @throws common_exception_NoImplementation
+     */
+    private function getTestPacker(){
+
+        //look at the item model
+        $testModel = $this->testService->getTestModel($this->test);
+        if(is_null($testModel)){
+            throw new common_exception_NoImplementation('No test model for test '.$this->test->getUri());
+        }
+
+        //get the testModel implementation for this model
+        $impl = $this->testService->getTestModelImplementation($testModel);
+        if(is_null($impl)){
+            throw new common_exception_NoImplementation('No implementation for model '.$testModel->getUri());
+        }
+
+        //then retrieve the packer class and instantiate it
+        $packerClass = new ReflectionClass($impl->getPackerClass());
+        if(is_null($packerClass) || !$packerClass->implementsInterface('oat\taoTests\models\pack\Packable')){
+            throw new common_exception_NoImplementation('The packer class seems to be not implemented');
+        }
+
+        return $packerClass->newInstance();
+    }
+
+    /**
+     * Pack a test.
+     *
+     * @return TestPack of the test. It can be serialized directly.
+     * @throws common_Exception
+     */
+    public function pack(){
+
+        try{
+            //call the factory to get the itemPacker implementation
+            $testPacker = $this->getTestPacker();
+
+            //then create the pack
+            $testPack = $testPacker->packTest($this->test);
+
+        } catch(Exception $e){
+            throw new common_Exception('The test '. $this->test->getUri() .' cannot be packed : ' . $e->getMessage());
+        }
+
+        return $testPack;
+    }
+}
+?>

--- a/models/classes/pack/TestPack.php
+++ b/models/classes/pack/TestPack.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoTests\models\pack;
+
+use \InvalidArgumentException;
+use \JsonSerializable;
+
+/**
+ * The Item Pack represents the item package data produced by the compilation.
+ *
+ * @package taoTests
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class TestPack implements JsonSerializable
+{
+    /**
+     * The item type
+     * @var string
+     */
+    private $type;
+
+    /**
+     * The item data as arrays. Can be anything, just be careful of cyclic refs.
+     * @var array
+     */
+    private $data = array();
+
+    /**
+     * The test item's data
+     * @var array
+     */
+    private $items = array();
+
+    /**
+     * Creates an TestPack with the required data.
+     *
+     * @param string $type the test type
+     * @param array $data the test data
+     * @param array $items the test items
+     * @throw InvalidArgumentException
+     */
+    public function __construct($type, $data, $items)
+    {
+        if(empty($type)){
+            throw new InvalidArgumentException('Please provide a test type');
+        }
+        if(!is_array($data)){
+            throw new InvalidArgumentException('Please provide the test data as an array');
+        }
+        if(!is_array($items)){
+            throw new InvalidArgumentException('Please provide the items as an array');
+        }
+        $this->type = $type;
+        $this->data = $data;
+        $this->items = $items;
+    }
+
+    /**
+     * Get the test type
+     * @return string the type
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get the test data
+     * @return array the data
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Get the test's items
+     * @return array the items
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * How to serialize the pack in JSON.
+     */
+    public function JsonSerialize()
+    {
+        return array(
+            'type'      => $this->type,
+            'data'      => $this->data,
+            'items'     => $this->items
+        );
+    }
+}
+?>

--- a/test/pack/PackerTest.php
+++ b/test/pack/PackerTest.php
@@ -1,0 +1,270 @@
+<?php
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+namespace oat\taoTests\test\pack;
+
+use \core_kernel_classes_Resource;
+use oat\taoTests\models\pack\Packer;
+use oat\taoTests\models\pack\Packable;
+use oat\taoTests\models\pack\TestPack;
+use oat\tao\test\TaoPhpUnitTestRunner;
+
+
+/**
+ * Test the class {@link TestPack}
+ *
+ * @author Bertrand Chevrier, <taosupport@tudor.lu>
+ * @package taoTests
+ */
+class PackerTest extends TaoPhpUnitTestRunner
+{
+
+    public function setUp()
+    {
+        \common_ext_ExtensionsManager::singleton()->getExtensionById('taoTests');
+    }
+
+    /**
+     * Test creating an TestPack
+     */
+    public function testConstructor(){
+        $test = new core_kernel_classes_Resource('toto');
+        $packer = new Packer($test);
+        $this->assertInstanceOf('oat\taoTests\models\pack\Packer', $packer);
+    }
+
+    /**
+     * Test assigning assets to a pack
+     */
+    public function testPack(){
+        $test = new core_kernel_classes_Resource('foo');
+        $model = new core_kernel_classes_Resource('fooModel');
+
+        $serviceMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_TestsService')
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $modelMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_TestModel')
+                        ->getMock();
+
+
+        $packerMock = new PackerMock();
+
+        $modelMock
+            ->method('getPackerClass')
+            ->will($this->returnValue(get_class($packerMock)));
+
+        $serviceMock
+            ->method('getTestModel')
+            ->will($this->returnValue(new core_kernel_classes_Resource('fooModel')));
+
+        $serviceMock
+            ->method('getTestContent')
+            ->will($this->returnValue(''));
+
+        $serviceMock
+            ->method('getTestModelImplementation')
+            ->with($this->equalTo($model))
+            ->will($this->returnValue($modelMock));
+
+        $serviceMock
+            ->method('singleton')
+            ->will($this->returnValue($serviceMock));
+
+
+        $packer = new Packer($test);
+
+        $prop = new \ReflectionProperty('oat\taoTests\models\pack\Packer', 'testService');
+        $prop->setAccessible(true);
+        $prop->setValue($packer, $serviceMock);
+
+
+        $result = $packer->pack();
+        $this->assertInstanceOf('oat\taoTests\models\pack\TestPack', $result);
+        $this->assertEquals('qti', $result->getType());
+        $this->assertEquals(array('uri' => $test->getUri()), $result->getData());
+
+    }
+
+    /**
+     * Test the exception chain when the test has no model
+     *
+     * @expectedException \common_Exception
+     */
+    public function testNoTestModel(){
+        $test = new core_kernel_classes_Resource('foo');
+
+        $serviceMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_TestsService')
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $serviceMock
+            ->method('getTestModel')
+            ->will($this->returnValue(null));
+
+        $serviceMock
+            ->method('singleton')
+            ->will($this->returnValue($serviceMock));
+
+
+        $packer = new Packer($test);
+
+        $prop = new \ReflectionProperty('oat\taoTests\models\pack\Packer', 'testService');
+        $prop->setAccessible(true);
+        $prop->setValue($packer, $serviceMock);
+
+        $packer->pack();
+    }
+
+    /**
+     * Test the exception chain when there is no implementations for a model
+     *
+     * @expectedException \common_Exception
+     */
+    public function testNoModelImplementation(){
+        $test = new core_kernel_classes_Resource('foo');
+        $model = new core_kernel_classes_Resource('fooModel');
+
+        $serviceMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_TestsService')
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $serviceMock
+            ->method('getTestModel')
+            ->will($this->returnValue($model));
+
+        $serviceMock
+            ->method('getTestModelImplementation')
+            ->with($this->equalTo($model))
+            ->will($this->returnValue(null));
+
+        $serviceMock
+            ->method('singleton')
+            ->will($this->returnValue($serviceMock));
+
+
+        $packer = new Packer($test);
+
+        $prop = new \ReflectionProperty('oat\taoTests\models\pack\Packer', 'testService');
+        $prop->setAccessible(true);
+        $prop->setValue($packer, $serviceMock);
+
+        $packer->pack();
+    }
+
+    /**
+     * Test the exception chain when the model does not return a correct packer class
+     *
+     * @expectedException \common_Exception
+     */
+    public function testNoPackerClass(){
+
+        $test = new core_kernel_classes_Resource('foo');
+
+        $serviceMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_TestsService')
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $modelMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_testModel')
+                        ->getMock();
+
+
+        $modelMock
+            ->method('getPackerClass')
+            ->will($this->returnValue(null));
+
+        $serviceMock
+            ->method('getTestModel')
+            ->will($this->returnValue(new core_kernel_classes_Resource('fooModel')));
+
+        $serviceMock
+            ->method('getTestModelImplementation')
+            ->will($this->returnValue($modelMock));
+
+        $serviceMock
+            ->method('singleton')
+            ->will($this->returnSelf());
+
+
+        $packer = new Packer($test);
+
+        $prop = new \ReflectionProperty('oat\taoTests\models\pack\Packer', 'testService');
+        $prop->setAccessible(true);
+        $prop->setValue($packer, $serviceMock);
+
+        $packer->pack();
+    }
+
+    /**
+     * Test the exception chain when the model returns a wrong packer class
+     *
+     * @expectedException \common_Exception
+     */
+    public function testWrongPackerClass(){
+
+        $test = new core_kernel_classes_Resource('foo');
+
+        $serviceMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_TestsService')
+                        ->disableOriginalConstructor()
+                        ->getMock();
+
+        $modelMock = $this
+                        ->getMockBuilder('\taoTests_models_classes_testModel')
+                        ->getMock();
+
+        $modelMock
+            ->method('getPackerClass')
+            ->will($this->returnValue("stdClass"));
+
+        $serviceMock
+            ->method('getTestModel')
+            ->will($this->returnValue(new core_kernel_classes_Resource('fooModel')));
+
+        $serviceMock
+            ->method('getTestModelImplementation')
+            ->will($this->returnValue($modelMock));
+
+        $serviceMock
+            ->method('singleton')
+            ->will($this->returnSelf());
+
+
+        $packer = new Packer($test);
+
+        $prop = new \ReflectionProperty('oat\taoTests\models\pack\Packer', 'testService');
+        $prop->setAccessible(true);
+        $prop->setValue($packer, $serviceMock);
+
+        $packer->pack();
+    }
+}
+
+//use an old school mock as the Packer create it's own instance from the class
+class PackerMock implements Packable{
+    public function packTest(core_kernel_classes_Resource $test){
+        return new TestPack('qti', array('uri' => $test->getUri()), array());
+    }
+}

--- a/test/pack/TestPackTest.php
+++ b/test/pack/TestPackTest.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ *
+ */
+namespace oat\taoTests\test\pack;
+
+use oat\taoTests\models\pack\TestPack;
+use oat\tao\test\TaoPhpUnitTestRunner;
+
+/**
+ * Test the class {@link TestPack}
+ *
+ * @author Bertrand Chevrier, <taosupport@tudor.lu>
+ * @package taoTests
+ */
+class TestPackTest extends TaoPhpUnitTestRunner
+{
+
+    /**
+     * Test creating an TestPack
+     */
+    public function testConstructor(){
+        $type = 'qti';
+        $data = array('foo' => 'bar');
+        $items= array();
+
+        $pack = new TestPack($type, $data, $items);
+        $this->assertInstanceOf('oat\taoTests\models\pack\TestPack', $pack);
+        $this->assertEquals($type, $pack->getType());
+        $this->assertEquals($data, $pack->getData());
+        $this->assertEquals($items, $pack->getItems());
+    }
+
+
+    /**
+     * Test the constructor with an empty type
+     * @expectedException InvalidArgumentException
+     */
+    public function testWrongTypeConstructor(){
+        new TestPack(null, array(), array());
+    }
+
+    /**
+     * Test the constructor with invalid data
+     * @expectedException InvalidArgumentException
+     */
+    public function testWrongDataConstructor(){
+        new TestPack('qti', '{"foo":"bar"}', array());
+    }
+
+    /**
+     * Test the constructor with invalid data
+     * @expectedException InvalidArgumentException
+     */
+    public function testWrongItemsConstructor(){
+        new TestPack('qti', array(), 'foo');
+    }
+
+    /**
+     * Provides data to test the bundle
+     * @return array() the data
+     */
+    public function jsonSerializableProvider(){
+
+        $data = array();
+
+
+
+        return $data;
+    }
+
+    /**
+     * Test the testPack serializaion
+     */
+    public function testSerialization(){
+
+       $testPack = new TestPack('qti', array('foo' => 'bar'), array('foo', 'bar'));
+
+       $expected = '{"type":"qti","data":{"foo":"bar"},"items":["foo","bar"]}';
+
+       $this->assertInstanceOf('oat\taoTests\models\pack\TestPack', $testPack);
+       $this->assertTrue(is_string($expected));
+       $this->assertEquals($expected, json_encode($testPack));
+    }
+
+}


### PR DESCRIPTION
 This is the packing abstraction. Packing is used to retrieve the test data needed to run a test. 

Depends on oat-sa/extension-tao-testlinear#4
Depends on oat-sa/extension-tao-testqti#34 