### PR TITLE
Increase timeout for phatomjs

### DIFF
--- a/views/js/test/runner/probeOverseer/test.js
+++ b/views/js/test/runner/probeOverseer/test.js
@@ -259,7 +259,7 @@ define([
                         }).catch(function(err) {
                             assert.ok(false, err);
                         });
-                    }, 50); //time to write in the db
+                    }, 150); //time to write in the db
                 })
                 .init();
         });


### PR DESCRIPTION
On the build server, phantomJs seems slow to write a value in IndexDB.