### PR TITLE
Increase TimePoint precision

### DIFF
--- a/models/classes/runner/time/TimePoint.php
+++ b/models/classes/runner/time/TimePoint.php
@@ -67,7 +67,7 @@ class TimePoint implements \Serializable
     /**
      * The decimal precision used to compare timestamps
      */
-    const PRECISION = 1000;
+    const PRECISION = 10000;
 
     /**
      * The timestamp representing the TimePoint


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2487

Increase timestamp precision when normalizing a TimePoint for comparisons.

This is needed to fix sort issue with very close timestamps.