### PR TITLE
Fix TimePoint comparison

### DIFF
--- a/models/classes/runner/time/TimePoint.php
+++ b/models/classes/runner/time/TimePoint.php
@@ -351,8 +351,8 @@ class TimePoint implements \Serializable
      * The comparison is made in this order:
      * - reference
      * - target
-     * - type
      * - timestamp
+     * - type
      * 
      * CAUTION!: The result order is not based on chronological order. 
      * Its goal is to gather TimePoint by reference and target, then sort by type and timestamp.
@@ -366,9 +366,9 @@ class TimePoint implements \Serializable
         if ($diff == 0) {
             $diff = $this->getTarget() - $point->getTarget();
             if ($diff == 0) {
-                $diff = $this->getType() - $point->getType();
+                $diff = $this->getNormalizedTimestamp() - $point->getNormalizedTimestamp();
                 if ($diff == 0) {
-                    $diff = $this->getNormalizedTimestamp() - $point->getNormalizedTimestamp();
+                    $diff = $this->getType() - $point->getType();
                 }
             }
         }

--- a/models/classes/runner/time/TimePoint.php
+++ b/models/classes/runner/time/TimePoint.php
@@ -94,6 +94,12 @@ class TimePoint implements \Serializable
     protected $target = 0;
 
     /**
+     * The unique reference to name the TimePoint
+     * @var string
+     */
+    protected $ref;
+
+    /**
      * QtiTimePoint constructor.
      * @param string|array $tags
      * @param float $timestamp
@@ -246,11 +252,12 @@ class TimePoint implements \Serializable
     public function addTag($tag)
     {
         $this->tags[] = (string)$tag;
+        $this->ref = null;
         return $this;
     }
 
     /**
-     * Remove a tag from the TimePoint
+     * Removes a tag from the TimePoint
      * @param string $tag
      * @return TimePoint
      */
@@ -260,6 +267,7 @@ class TimePoint implements \Serializable
 
         if ($index !== false) {
             array_splice($this->tags, $index, 1);
+            $this->ref = null;
         }
 
         return $this;
@@ -284,6 +292,7 @@ class TimePoint implements \Serializable
     public function setTags($tags)
     {
         $this->tags = [];
+        $this->ref = null;
 
         if (is_array($tags)) {
             foreach ($tags as $tag) {
@@ -311,9 +320,12 @@ class TimePoint implements \Serializable
      */
     public function getRef()
     {
-        $tags = $this->tags;
-        sort($tags);
-        return md5(implode('-', $tags));
+        if (is_null($this->ref)) {
+            $tags = $this->tags;
+            sort($tags);
+            $this->ref = md5(implode('-', $tags));
+        }
+        return $this->ref;
     }
 
     /**
@@ -335,19 +347,43 @@ class TimePoint implements \Serializable
     }
 
     /**
-     * Compare the TimePoint with another instance
+     * Compares the TimePoint with another instance.
+     * The comparison is made in this order:
+     * - reference
+     * - target
+     * - type
+     * - timestamp
+     * 
+     * CAUTION!: The result order is not based on chronological order. 
+     * Its goal is to gather TimePoint by reference and target, then sort by type and timestamp.
+     * 
      * @param TimePoint $point
      * @return int
      */
     public function compare(TimePoint $point)
     {
-        $diff = $this->getNormalizedTimestamp() - $point->getNormalizedTimestamp();
+        $diff = strcmp($this->getRef(), $point->getRef());
         if ($diff == 0) {
-            $diff = $this->getType() - $point->getType();
+            $diff = $this->getTarget() - $point->getTarget();
             if ($diff == 0) {
-                $diff = $this->getTarget() - $point->getTarget();
+                $diff = $this->getType() - $point->getType();
+                if ($diff == 0) {
+                    $diff = $this->getNormalizedTimestamp() - $point->getNormalizedTimestamp();
+                }
             }
         }
         return $diff;
+    }
+
+    /**
+     * Sorts a range of TimePoint
+     * @param array $range
+     * @return array
+     */
+    public static function sort(array &$range) {
+        usort($range, function(TimePoint $a, TimePoint $b) {
+            return $a->compare($b);
+        });
+        return $range;
     }
 }

--- a/test/runner/time/TimerPointTest.php
+++ b/test/runner/time/TimerPointTest.php
@@ -177,6 +177,15 @@ class TimerPointTest extends TaoPhpUnitTestRunner
     }
 
     /**
+     * Test TimePoint::sort() method
+     * @dataProvider testSortProvider
+     */
+    public function testSort(array $range, array $expectedResult)
+    {
+        $this->assertEquals($expectedResult, TimePoint::sort($range));
+    }
+
+    /**
      * @return array
      */
     public function testSerializeProvider()
@@ -238,6 +247,63 @@ class TimerPointTest extends TaoPhpUnitTestRunner
                 new TimePoint(null, 1459335300, TimePoint::TYPE_START, TimePoint::TARGET_CLIENT),
                 new TimePoint(null, 1459335300, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
                 -1,
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function testSortProvider()
+    {
+        $points1 = [
+            0 => new TimePoint(['item-1', 'item-1#0'], 1459335300, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            1 => new TimePoint(['item-2', 'item-2#0'], 1459335320, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            2 => new TimePoint(['item-1', 'item-1#1'], 1459335340, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+
+            3 => new TimePoint(['item-1', 'item-1#0'], 1459335310, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+            4 => new TimePoint(['item-2', 'item-2#0'], 1459335330, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+            5 => new TimePoint(['item-1', 'item-1#1'], 1459335350, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+        ];
+
+        $points2 = [
+            0 => new TimePoint(['item-1', 'item-1#0'], 1459335300, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            1 => new TimePoint(['item-2', 'item-2#0'], 1459335320, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            2 => new TimePoint(['item-1', 'item-1#1'], 1459335340, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+
+            3 => new TimePoint(['item-1', 'item-1#0'], 1459335305, TimePoint::TYPE_START, TimePoint::TARGET_CLIENT),
+            4 => new TimePoint(['item-2', 'item-2#0'], 1459335325, TimePoint::TYPE_START, TimePoint::TARGET_CLIENT),
+            5 => new TimePoint(['item-1', 'item-1#1'], 1459335345, TimePoint::TYPE_START, TimePoint::TARGET_CLIENT),
+
+            6 => new TimePoint(['item-1', 'item-1#0'], 1459335315, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+            7 => new TimePoint(['item-2', 'item-2#0'], 1459335335, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+            8 => new TimePoint(['item-1', 'item-1#1'], 1459335355, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+
+            9 => new TimePoint(['item-1', 'item-1#0'], 1459335310, TimePoint::TYPE_END, TimePoint::TARGET_CLIENT),
+            10 => new TimePoint(['item-2', 'item-2#0'], 1459335330, TimePoint::TYPE_END, TimePoint::TARGET_CLIENT),
+            11 => new TimePoint(['item-1', 'item-1#1'], 1459335350, TimePoint::TYPE_END, TimePoint::TARGET_CLIENT),
+        ];
+
+
+        return [
+            [
+                $points1,
+                [
+                    $points1[1], $points1[4], // item-2#0
+                    $points1[2], $points1[5], // item-1#1
+                    $points1[0], $points1[3], // item-1#0
+                ],
+            ],
+            [
+                $points2,
+                [
+                    $points2[4], $points2[10],  // item-2#0 client
+                    $points2[1], $points2[7],   // item-2#0 server
+                    $points2[5], $points2[11],  // item-1#1 client
+                    $points2[2], $points2[8],   // item-1#1 server
+                    $points2[3], $points2[9],   // item-1#0 client
+                    $points2[0], $points2[6],   // item-1#0 server
+                ],
             ],
         ];
     }

--- a/test/runner/time/TimerPointTest.php
+++ b/test/runner/time/TimerPointTest.php
@@ -283,6 +283,17 @@ class TimerPointTest extends TaoPhpUnitTestRunner
             10 => new TimePoint(['item-2', 'item-2#0'], 1459335330, TimePoint::TYPE_END, TimePoint::TARGET_CLIENT),
             11 => new TimePoint(['item-1', 'item-1#1'], 1459335350, TimePoint::TYPE_END, TimePoint::TARGET_CLIENT),
         ];
+        
+        $points3 = [
+            0 => new TimePoint(['item-1', 'item-1#0'], 1460116638.5226, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            1 => new TimePoint(['item-1', 'item-1#0'], 1460116645.4868, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+
+            2 => new TimePoint(['item-1', 'item-1#0'], 1460116646.2684, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            3 => new TimePoint(['item-1', 'item-1#0'], 1460116653.7042, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+
+            4 => new TimePoint(['item-1', 'item-1#0'], 1460116733.6273, TimePoint::TYPE_START, TimePoint::TARGET_SERVER),
+            5 => new TimePoint(['item-1', 'item-1#0'], 1460116784.4006, TimePoint::TYPE_END, TimePoint::TARGET_SERVER),
+        ];
 
 
         return [
@@ -305,6 +316,10 @@ class TimerPointTest extends TaoPhpUnitTestRunner
                     $points2[0], $points2[6],   // item-1#0 server
                 ],
             ],
+            [
+                $points3,
+                $points3,
+            ]
         ];
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2487

Fix the TimePoint comparison method.
Add a sort helper.

The goal of the comparison is to gather TimePoint by tags and target, then sort by type and timestamp.
The sort helper just provides a way to gather TimePoint in order to compute durations by ranges. A range must always be represented by a pair of start/end TimePoint with the same target and tags.

If the need arises someday, we will add a chronological sorter, but for now there is no use case.