### PR TITLE
Enable to get a plugin by it's name

### DIFF
--- a/views/js/runner/plugin.js
+++ b/views/js/runner/plugin.js
@@ -237,6 +237,14 @@ define([
                     return this;
                 },
 
+                /**
+                 * Get the plugin name
+                 *
+                 * @returns {String} the name
+                 */
+                getName : function getName(){
+                    return pluginName;
+                },
 
                 /**
                  * Shows the component related to this plugin

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -174,7 +174,8 @@ define([
 
                 //instantiate the plugins first
                 _.forEach(pluginFactories, function(pluginFactory, pluginName){
-                    plugins[pluginName] = pluginFactory(runner, self.getAreaBroker());
+                    var plugin = pluginFactory(runner, self.getAreaBroker());
+                    plugins[plugin.getName()] = plugin;
                 });
 
                 providerRun('init').then(function(){

--- a/views/js/test/runner/plugin/test.js
+++ b/views/js/test/runner/plugin/test.js
@@ -79,7 +79,7 @@ define([
     });
 
     QUnit.test('create a plugin', function (assert){
-        QUnit.expect(19);
+        QUnit.expect(20);
 
         var myPlugin = pluginFactory(mockProvider, samplePluginDefaults);
 
@@ -105,6 +105,7 @@ define([
         assert.equal(typeof instance1.getState, 'function', 'The plugin instance has also the default function getState');
         assert.equal(typeof instance1.getConfig, 'function', 'The plugin instance has also the default function getConfig');
         assert.equal(typeof instance1.setConfig, 'function', 'The plugin instance has also the default function setConfig');
+        assert.equal(typeof instance1.getName, 'function', 'The plugin instance has also the default function getName');
 
         // check default config
         var config1 = instance1.getConfig();
@@ -277,6 +278,30 @@ define([
             });
 
         var instance1 = myPlugin(testRunner);
+        instance1.init();
+    });
+
+    QUnit.asyncTest('get plugin name', function(assert){
+        QUnit.expect(3);
+
+        var name = 'foo-plugin';
+        var testRunner = {
+            trigger: _.noop
+        };
+
+        var samplePluginImpl = {
+            name : name,
+            init : function (){
+                assert.ok(true, 'called init');
+                assert.equal(this.getName(), name, 'The name matches');
+                QUnit.start();
+            }
+        };
+
+        var myPlugin = pluginFactory(samplePluginImpl);
+
+        var instance1 = myPlugin(testRunner);
+        assert.equal(instance1.getName(), name, 'The name matches');
         instance1.init();
     });
 });


### PR DESCRIPTION
To make working `runner.getPlugin(name)`