### PR TITLE
Add middleware handler on runner proxy

### DIFF
--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -20,10 +20,11 @@
  */
 define([
     'lodash',
+    'async',
     'core/eventifier',
     'taoTests/runner/proxyRegistry',
     'taoTests/runner/tokenHandler'
-], function(_, eventifier, proxyRegistry, tokenHandlerFactory) {
+], function(_, async, eventifier, proxyRegistry, tokenHandlerFactory) {
     'use strict';
 
     var _defaults = {};
@@ -43,7 +44,56 @@ define([
         var extraCallParams = {};
         var proxyAdapter    = proxyFactory.getProxy(proxyName);
         var initConfig      = _.defaults(config || {}, _defaults);
-        var tokenHandler   = tokenHandlerFactory();
+        var tokenHandler    = tokenHandlerFactory();
+        var middlewares     = {};
+
+        /**
+         * Gets the aggregated list of middlewares for a particular queue name
+         * @param {String} queue - The name of the queue to get
+         * @returns {Array}
+         */
+        function getMiddlewares(queue) {
+            var list = middlewares[queue] || [];
+            if (middlewares.all) {
+                list = list.concat(middlewares.all);
+            }
+            return list;
+        }
+
+        /**
+         * Applies the list of registered middlewares onto the received response
+         * @param {Object} request - The request descriptor
+         * @param {String} request.command - The name of the requested command
+         * @param {Object} request.params - The map of provided parameters
+         * @param {Object} response The response descriptor
+         * @param {String} response.status The status of the response, can be either 'success' or 'error'
+         * @param {Object} response.data The full response data
+         * @returns {Promise}
+         */
+        function applyMiddlewares(request, response) {
+            // wrap each middleware to provide parameters
+            var list = _.map(getMiddlewares(request.command), function(middleware) {
+                return function(next) {
+                    middleware(request, response, next);
+                };
+            });
+
+            // apply each middleware in series, then resolve or reject the promise
+            return new Promise(function(resolve, reject) {
+                async.series(list, function(err) {
+                    // handle implicit error from response descriptor
+                    if (!err && 'error' === response.status) {
+                        err = response.data;
+                    }
+
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(response.data);
+                    }
+                });
+            });
+        }
 
         /**
          * Delegates a function call to the selected proxy.
@@ -56,15 +106,30 @@ define([
          * @throws Error
          */
         function delegate(fnName, args) {
-            var promise;
+            var promise, request;
 
             if (proxyAdapter) {
                 if (_.isFunction(proxyAdapter[fnName])) {
                     // need real array of params, even if empty
                     args = args ? _slice.call(args) : [];
 
-                    // delegate the call to the adapter
-                    promise = proxyAdapter[fnName].apply(proxy, args);
+                    // delegate the call to the adapter and apply the middleware
+                    request = {command: fnName, params: args};
+                    promise = proxyAdapter[fnName].apply(proxy, args)
+                        .then(function(data) {
+                            // handle successful request
+                            return applyMiddlewares(request, {
+                                status: 'success',
+                                data: data
+                            });
+                        })
+                        .catch(function(data) {
+                            // handle failed request
+                            return applyMiddlewares(request, {
+                                status: 'error',
+                                data: data
+                            });
+                        });
 
                     // fire the method related event
                     // the promise has to be provided as first argument in all events
@@ -84,6 +149,25 @@ define([
          * @type {proxy}
          */
         var proxy = eventifier({
+            /**
+             * Add a middleware
+             * @param {String} [command] The command queue in which add the middleware (default: 'all')
+             * @param {Function} callback A middleware callback. Must accept 3 parameters: request, response, next.
+             * @returns {proxy}
+             */
+            use: function use(command, callback) {
+                var queue = command && _.isString(command) ? command : 'all';
+                var list = middlewares[queue] || [];
+                middlewares[queue] = list;
+
+                _.each(arguments, function(callback) {
+                    if (_.isFunction(callback)) {
+                        list.push(callback);
+                    }
+                });
+                return this;
+            },
+
             /**
              * Initializes the proxy
              * @returns {Promise} - Returns a promise. The proxy will be fully initialized on resolve.

--- a/views/js/test/runner/proxy/test.js
+++ b/views/js/test/runner/proxy/test.js
@@ -18,24 +18,23 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
+define(['lodash', 'core/promise', 'taoTests/runner/proxy'], function(_, Promise, proxyFactory) {
     'use strict';
 
     QUnit.module('proxyFactory');
 
     var defaultProxy = {
-        init : function() {},
-        destroy : function() {},
-        getTestData : function() {},
-        getTestContext : function() {},
-        getTestMap : function() {},
-        callTestAction : function() {},
-        getItem : function() {},
-        submitItem : function() {},
-        callItemAction : function() {},
-        telemetry : function() {}
+        init : function() { return Promise.resolve(); },
+        destroy : function() { return Promise.resolve(); },
+        getTestData : function() { return Promise.resolve(); },
+        getTestContext : function() { return Promise.resolve(); },
+        getTestMap : function() { return Promise.resolve(); },
+        callTestAction : function() { return Promise.resolve(); },
+        getItem : function() { return Promise.resolve(); },
+        submitItem : function() { return Promise.resolve(); },
+        callItemAction : function() { return Promise.resolve(); },
+        telemetry : function() { return Promise.resolve(); }
     };
-
 
     QUnit.test('module', function(assert) {
         QUnit.expect(5);
@@ -75,12 +74,6 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
 
     QUnit.asyncTest('proxyFactory.init', function(assert) {
         var initConfig = {};
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
 
         QUnit.expect(6);
         QUnit.stop();
@@ -90,29 +83,22 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
                 assert.ok(true, 'The proxyFactory has delegated the call to init');
                 assert.equal(config, initConfig, 'The proxyFactory has provided the config object to the init method');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default', initConfig).on('init', function(p, config) {
             assert.ok(true, 'The proxyFactory has fired the "init" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "init" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "init" event');
             assert.equal(config, initConfig, 'The proxyFactory has provided the config object through the "init" event');
             QUnit.start();
         }).init();
 
-        assert.equal(result, promise, 'The proxyFactory.init method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.init method has returned a promise');
     });
 
 
     QUnit.asyncTest('proxyFactory.destroy', function(assert) {
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
-
         QUnit.expect(4);
         QUnit.stop();
 
@@ -120,28 +106,21 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
             destroy : function() {
                 assert.ok(true, 'The proxyFactory has delegated the call to destroy');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('destroy', function(p) {
             assert.ok(true, 'The proxyFactory has fired the "destroy" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "destroy" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "destroy" event');
             QUnit.start();
         }).destroy();
 
-        assert.equal(result, promise, 'The proxyFactory.destroy method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.destroy method has returned a promise');
     });
 
 
     QUnit.asyncTest('proxyFactory.getTestData', function(assert) {
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
-
         QUnit.expect(4);
         QUnit.stop();
 
@@ -149,28 +128,21 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
             getTestData : function() {
                 assert.ok(true, 'The proxyFactory has delegated the call to getTestData');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('getTestData', function(p) {
             assert.ok(true, 'The proxyFactory has fired the "getTestData" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "getTestData" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "getTestData" event');
             QUnit.start();
         }).getTestData();
 
-        assert.equal(result, promise, 'The proxyFactory.getTestData method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.getTestData method has returned a promise');
     });
 
 
     QUnit.asyncTest('proxyFactory.getTestContext', function(assert) {
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
-
         QUnit.expect(4);
         QUnit.stop();
 
@@ -178,28 +150,21 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
             getTestContext : function() {
                 assert.ok(true, 'The proxyFactory has delegated the call to getTestContext');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('getTestContext', function(p) {
             assert.ok(true, 'The proxyFactory has fired the "getTestContext" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "getTestContext" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "getTestContext" event');
             QUnit.start();
         }).getTestContext();
 
-        assert.equal(result, promise, 'The proxyFactory.getTestContext method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.getTestContext method has returned a promise');
     });
 
 
     QUnit.asyncTest('proxyFactory.getTestMap', function(assert) {
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
-
         QUnit.expect(4);
         QUnit.stop();
 
@@ -207,17 +172,17 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
             getTestMap : function() {
                 assert.ok(true, 'The proxyFactory has delegated the call to getTestMap');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('getTestMap', function(p) {
             assert.ok(true, 'The proxyFactory has fired the "getTestMap" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "getTestMap" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "getTestMap" event');
             QUnit.start();
         }).getTestMap();
 
-        assert.equal(result, promise, 'The proxyFactory.getTestMap method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.getTestMap method has returned a promise');
     });
 
 
@@ -225,12 +190,6 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
         var expectedAction = 'test';
         var expectedParams = {
             foo : 'bar'
-        };
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
         };
 
         QUnit.expect(8);
@@ -242,30 +201,24 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
                 assert.equal(action, expectedAction, 'The proxyFactory has provided the action to the callTestAction method');
                 assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params to the callTestAction method');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('callTestAction', function(p, action, params) {
             assert.ok(true, 'The proxyFactory has fired the "callTestAction" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "callTestAction" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "callTestAction" event');
             assert.equal(action, expectedAction, 'The proxyFactory has provided the action through the "callTestAction" event');
             assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "callTestAction" event');
             QUnit.start();
         }).callTestAction(expectedAction, expectedParams);
 
-        assert.equal(result, promise, 'The proxyFactory.callTestAction method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.callTestAction method has returned a promise');
     });
 
 
     QUnit.asyncTest('proxyFactory.getItem', function(assert) {
         var expectedUri = 'http://tao.dev#item123';
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
 
         QUnit.expect(6);
         QUnit.stop();
@@ -275,18 +228,18 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
                 assert.ok(true, 'The proxyFactory has delegated the call to getItem');
                 assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI to the getItem method');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('getItem', function(p, uri) {
             assert.ok(true, 'The proxyFactory has fired the "getItem" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "getItem" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "getItem" event');
             assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI through the "getItem" event');
             QUnit.start();
         }).getItem(expectedUri);
 
-        assert.equal(result, promise, 'The proxyFactory.getItem method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.getItem method has returned a promise');
     });
 
 
@@ -295,13 +248,6 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
         var expectedState    = { state: true };
         var expectedResponse = { response: true };
         var expectedParams   = { duration : 12.12324 };
-
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
 
         QUnit.expect(12);
 
@@ -313,13 +259,13 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
                 assert.equal(response, expectedResponse, 'The proxyFactory has provided the response to the submitItem method');
                 assert.equal(params, expectedParams, 'The proxyFactory has provided the params to the submitItem method');
 
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('submitItem', function(p, uri, state, response, params) {
             assert.ok(true, 'The proxyFactory has fired the "submitItem" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "submitItem" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "submitItem" event');
             assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI through the "submitItem" event');
             assert.equal(state, expectedState, 'The proxyFactory has provided the state through the "submitItem" event');
             assert.equal(response, expectedResponse, 'The proxyFactory has provided the response through the "submitItem" event');
@@ -328,7 +274,7 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
             QUnit.start();
         }).submitItem(expectedUri, expectedState, expectedResponse, expectedParams);
 
-        assert.equal(result, promise, 'The proxyFactory.submitItem method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.submitItem method has returned a promise');
     });
 
 
@@ -336,12 +282,6 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
         var expectedUri = 'http://tao.dev#item123';
         var expectedAction = 'test';
         var expectedParams = {};
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
 
         QUnit.expect(10);
         QUnit.stop();
@@ -353,20 +293,20 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
                 assert.equal(action, expectedAction, 'The proxyFactory has provided the action to the callItemAction method');
                 assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params to the callItemAction method');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('callItemAction', function(p, uri, action, params) {
             assert.ok(true, 'The proxyFactory has fired the "callItemAction" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "callItemAction" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "callItemAction" event');
             assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI through the "callItemAction" event');
             assert.equal(action, expectedAction, 'The proxyFactory has provided the action through the "callItemAction" event');
             assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "callItemAction" event');
             QUnit.start();
         }).callItemAction(expectedUri, expectedAction, expectedParams);
 
-        assert.equal(result, promise, 'The proxyFactory.callItemAction method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.callItemAction method has returned a promise');
     });
 
 
@@ -374,12 +314,6 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
         var expectedUri = 'http://tao.dev#item123';
         var expectedSignal = 'test';
         var expectedParams = {};
-        var promise = {
-            resolve: function() {},
-            reject: function() {},
-            then: function() {},
-            catch: function() {}
-        };
 
         QUnit.expect(10);
         QUnit.stop();
@@ -391,20 +325,20 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
                 assert.equal(signal, expectedSignal, 'The proxyFactory has provided the signal to the telemetry method');
                 assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params to the telemetry method');
                 QUnit.start();
-                return promise;
+                return Promise.resolve();
             }
         }, defaultProxy));
 
         var result = proxyFactory('default').on('telemetry', function(p, uri, signal, params) {
             assert.ok(true, 'The proxyFactory has fired the "telemetry" event');
-            assert.equal(p, promise, 'The proxyFactory has provided the promise through the "telemetry" event');
+            assert.ok(p instanceof Promise, 'The proxyFactory has provided the promise through the "telemetry" event');
             assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI through the "telemetry" event');
             assert.equal(signal, expectedSignal, 'The proxyFactory has provided the signal through the "telemetry" event');
             assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "telemetry" event');
             QUnit.start();
         }).telemetry(expectedUri, expectedSignal, expectedParams);
 
-        assert.equal(result, promise, 'The proxyFactory.telemetry method has returned a promise');
+        assert.ok(result instanceof Promise, 'The proxyFactory.telemetry method has returned a promise');
     });
 
 
@@ -462,5 +396,75 @@ define(['lodash', 'taoTests/runner/proxy'], function(_, proxyFactory) {
         assert.equal(typeof securityToken.getToken, 'function', 'The securityToken handler has a getToken method');
         assert.equal(typeof securityToken.setToken, 'function', 'The securityToken handler has a setToken method');
 
+    });
+
+
+    QUnit.asyncTest('proxyFactory.use#success', function(assert) {
+        QUnit.expect(18);
+
+        proxyFactory.registerProxy('default', defaultProxy);
+
+        var proxy = proxyFactory('default');
+
+        proxy
+            .use(function(req, res, next) {
+                assert.ok(true, 'The global middleware has been called');
+                assert.equal(typeof req, 'object', 'The request object has been provided');
+                assert.equal(typeof req.command, 'string', 'The request command has been provided');
+                assert.equal(typeof res, 'object', 'The response object has been provided');
+                assert.equal(typeof res.status, 'string', 'The response status has been provided');
+                assert.equal(res.status, 'success', 'The response has a success status');
+                next();
+            })
+            .use('init', function(req, res, next) {
+                assert.ok(true, 'The init middleware has been called');
+                assert.equal(typeof req, 'object', 'The request object has been provided');
+                assert.equal(typeof req.command, 'string', 'The request command has been provided');
+                assert.equal(typeof res, 'object', 'The response object has been provided');
+                assert.equal(typeof res.status, 'string', 'The response status has been provided');
+                assert.equal(res.status, 'success', 'The response has a success status');
+                next();
+            })
+            .init().then(function() {
+                proxy.getTestData().then(function() {
+                    QUnit.start();
+                });
+            });
+    });
+
+
+    QUnit.asyncTest('proxyFactory.use#fail', function(assert) {
+        QUnit.expect(12);
+
+        proxyFactory.registerProxy('default', _.defaults({
+            init : function() {
+                return Promise.reject('error');
+            }
+        }, defaultProxy));
+
+        var proxy = proxyFactory('default');
+
+        proxy
+            .use(function(req, res, next) {
+                assert.ok(true, 'The global middleware has been called');
+                assert.equal(typeof req, 'object', 'The request object has been provided');
+                assert.equal(typeof req.command, 'string', 'The request command has been provided');
+                assert.equal(typeof res, 'object', 'The response object has been provided');
+                assert.equal(typeof res.status, 'string', 'The response status has been provided');
+                assert.equal(res.status, 'error', 'The response has a failed status');
+                next();
+            })
+            .use('init', function(req, res, next) {
+                assert.ok(true, 'The init middleware has been called');
+                assert.equal(typeof req, 'object', 'The request object has been provided');
+                assert.equal(typeof req.command, 'string', 'The request command has been provided');
+                assert.equal(typeof res, 'object', 'The response object has been provided');
+                assert.equal(typeof res.status, 'string', 'The response status has been provided');
+                assert.equal(res.status, 'error', 'The response has a failed status');
+                next();
+            })
+            .init().catch(function() {
+                QUnit.start();
+            });
     });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2561

Add middleware in the test runner proxies.

Each middleware must comply with this signature: `function(request, response, next)`
With:
- `request`: an object providing the request command and its parameters
- `response`: an object providing the status and the received data
- `next`: a callback to call once the middleware has achieved its stuff