### PR TITLE
Wrap communicator

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,11 +34,12 @@ return array(
     'label' => 'Test core extension',
 	'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '2.17.0',
+    'version' => '2.17.1',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
 	    'taoItems' => '>=2.6',
-	    'taoBackOffice' => '>=0.8'
+	    'taoBackOffice' => '>=0.8',
+		'tao' => '>=3.1.0'
     ),
 	'models' => array(
 		'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
 	'requires' => array(
 	    'taoItems' => '>=2.6',
 	    'taoBackOffice' => '>=0.8',
-		'tao' => '>=3.1.0'
+		'tao' => '>=3.2.0'
     ),
 	'models' => array(
 		'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -45,7 +45,7 @@ class Updater extends \common_ext_ExtensionUpdater
 		    $this->setVersion('2.7.1');
 		}
 
-		$this->skip('2.7.1','2.17.0');
+		$this->skip('2.7.1','2.17.1');
         
 		return null;
 	}

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -223,7 +223,7 @@ define([
                 if (!communicatorPromise) {
                     communicatorPromise = new Promise(function(resolve, reject) {
                         if (_.isFunction(proxyAdapter.loadCommunicator)) {
-                            communicator = proxyAdapter.loadCommunicator.call(this);
+                            communicator = proxyAdapter.loadCommunicator.call(self);
                             if (communicator) {
                                 communicator
                                     .on('error', function(error) {

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -405,8 +405,8 @@ define([
                     }
                     proxy = provider.loadProxy.call(this);
 
-                    proxy.on('error', function (data) {
-                        self.trigger('error', data);
+                    proxy.on('error', function (error) {
+                        self.trigger('error', error);
                     });
                 }
                 return proxy;

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -398,11 +398,16 @@ define([
              * @returns {proxy} the proxy
              */
             getProxy : function getProxy(){
+                var self = this;
                 if(!proxy){
                     if(!_.isFunction(provider.loadProxy)){
                         throw new Error('The provider does not have a loadProxy method');
                     }
                     proxy = provider.loadProxy.call(this);
+
+                    proxy.on('error', function (data) {
+                        self.trigger('error', data);
+                    });
                 }
                 return proxy;
             },

--- a/views/js/test/runner/proxy/test.js
+++ b/views/js/test/runner/proxy/test.js
@@ -18,10 +18,14 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['lodash', 'core/promise', 'taoTests/runner/proxy'], function(_, Promise, proxyFactory) {
+define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], function(_, Promise, eventifier, proxyFactory) {
     'use strict';
 
-    QUnit.module('proxyFactory');
+    QUnit.module('proxyFactory', {
+        setup: function () {
+            proxyFactory.clearProviders();
+        }
+    });
 
     var defaultProxy = {
         init : _.noop,
@@ -54,6 +58,9 @@ define(['lodash', 'core/promise', 'taoTests/runner/proxy'], function(_, Promise,
         { name : 'init', title : 'init' },
         { name : 'destroy', title : 'destroy' },
         { name : 'getTokenHandler', title : 'getTokenHandler' },
+        { name : 'getCommunicator', title : 'getCommunicator' },
+        { name : 'channel', title : 'channel' },
+        { name : 'send', title : 'send' },
         { name : 'addCallActionParams', title : 'addCallActionParams' },
         { name : 'getTestData', title : 'getTestData' },
         { name : 'getTestContext', title : 'getTestContext' },
@@ -67,7 +74,8 @@ define(['lodash', 'core/promise', 'taoTests/runner/proxy'], function(_, Promise,
     QUnit
         .cases(proxyApi)
         .test('instance API ', function(data, assert) {
-            var instance = proxyFactory();
+            proxyFactory.registerProvider('default', defaultProxy);
+            var instance = proxyFactory('default');
             QUnit.expect(1);
             assert.equal(typeof instance[data.name], 'function', 'The proxyFactory instance exposes a "' + data.title + '" function');
         });
@@ -408,16 +416,25 @@ define(['lodash', 'core/promise', 'taoTests/runner/proxy'], function(_, Promise,
 
 
     QUnit.asyncTest('proxyFactory.getCommunicator', function(assert) {
-        QUnit.expect(3);
-        // QUnit.stop();
+        QUnit.expect(5);
 
         var expectedCommunicator = {
+            on: function() {
+                return this;
+            },
+            init: function() {
+                assert.ok(true, 'The communicator is initialized');
+                return Promise.resolve();
+            },
+            open: function() {
+                assert.ok(true, 'The communicator is open');
+                return Promise.resolve();
+            },
             destroy: function() {
                 assert.ok(true, 'The communicator must be destroyed when the proxy is destroying');
                 return Promise.resolve();
             }
         };
-        proxyFactory.registerProvider('default', defaultProxy);
 
         proxyFactory.registerProvider('communicator', {
             init: _.noop,
@@ -429,19 +446,172 @@ define(['lodash', 'core/promise', 'taoTests/runner/proxy'], function(_, Promise,
             }
         });
 
-        assert.throws(function() {
-            proxyFactory('default').getCommunicator();
-        }, 'An error is thrown when the loadCommunicator() method does not exists');
+        var proxy = proxyFactory('communicator');
+        proxy.getCommunicator().then(function(communicator) {
+            assert.equal(communicator, expectedCommunicator, 'The proxy has built a communicator handler');
+
+            proxy.getCommunicator().then(function(communicator) {
+                assert.equal(communicator, expectedCommunicator, 'The proxy returned the already built communicator handler');
+
+                proxy.destroy()
+                    .then(function() {
+                        QUnit.start();
+                    });
+            });
+        });
+    });
+
+
+    QUnit.asyncTest('proxyFactory.getCommunicator #no communicator', function(assert) {
+        QUnit.expect(1);
+
+
+        proxyFactory.registerProvider('communicator', {
+            init: _.noop,
+            loadCommunicator: _.noop
+        });
 
         var proxy = proxyFactory('communicator');
-        var communicator = proxy.getCommunicator();
+        proxy.getCommunicator().catch(function() {
+            assert.ok(true, 'An error is thrown when the loadCommunicator() does not return any communicator');
+            QUnit.start();
+        });
+    });
 
-        assert.equal(communicator, expectedCommunicator, 'The proxy has built a communicator handler');
 
-        proxy.destroy()
-            .then(function() {
+    QUnit.asyncTest('proxyFactory.getCommunicator #missing loadCommunicator', function(assert) {
+        QUnit.expect(1);
+
+        proxyFactory.registerProvider('default', defaultProxy);
+
+        proxyFactory('default').getCommunicator().catch(function() {
+            assert.ok(true, 'An error is thrown when the loadCommunicator() method does not exists');
+            QUnit.start();
+        });
+    });
+
+
+    QUnit.asyncTest('proxyFactory.getCommunicator #events', function(assert) {
+        QUnit.expect(6);
+        QUnit.stop(1);
+
+        var expectedCommunicator = eventifier({
+            init: function() {
+                assert.ok(true, 'The communicator is initialized');
+                return Promise.resolve();
+            },
+            open: function() {
+                assert.ok(true, 'The communicator is open');
+                return Promise.resolve();
+            }
+        });
+
+        var expectedError = 'error';
+        var expectedResponse = 'Hello';
+
+        proxyFactory.registerProvider('communicator', {
+            init: _.noop,
+            loadCommunicator: function() {
+                return expectedCommunicator;
+            }
+        });
+
+        var proxy = proxyFactory('communicator');
+
+        proxy
+            .on('error', function(error) {
+                assert.equal(error, expectedError, 'The right error has been caught');
                 QUnit.start();
+            })
+            .on('receive', function(response, context) {
+                assert.equal(response, expectedResponse, 'The right response has been received');
+                assert.equal(context, 'communicator', 'The right context has been set');
+                QUnit.start();
+            })
+            .getCommunicator().then(function(communicator) {
+                assert.equal(communicator, expectedCommunicator, 'The communicator is built');
+                communicator.trigger('error', expectedError);
+                communicator.trigger('receive', expectedResponse);
             });
+    });
+
+
+
+    QUnit.asyncTest('proxyFactory.channel', function(assert) {
+        QUnit.expect(5);
+
+        var expectedCommunicator = {
+            on: function() {
+                return this;
+            },
+            init: function() {
+                assert.ok(true, 'The communicator is initialized');
+                return Promise.resolve();
+            },
+            open: function() {
+                assert.ok(true, 'The communicator is open');
+                return Promise.resolve();
+            },
+            channel: function(name, handler) {
+                assert.equal(name, expectedName, 'The channel is created with the right name');
+                assert.equal(handler, expectedHandler, 'The channel is created with the right handler');
+                QUnit.start();
+            }
+        };
+
+        var expectedName = 'myChannel';
+        var expectedHandler = function() {};
+
+        proxyFactory.registerProvider('communicator', {
+            init: _.noop,
+            loadCommunicator: function() {
+                return expectedCommunicator;
+            }
+        });
+
+        var proxy = proxyFactory('communicator');
+        assert.equal(proxy.channel(expectedName, expectedHandler), proxy, 'The channel method returns the proxy instance');
+    });
+
+
+    QUnit.asyncTest('proxyFactory.send', function(assert) {
+        QUnit.expect(5);
+
+        var expectedCommunicator = {
+            on: function() {
+                return this;
+            },
+            init: function() {
+                assert.ok(true, 'The communicator is initialized');
+                return Promise.resolve();
+            },
+            open: function() {
+                assert.ok(true, 'The communicator is open');
+                return Promise.resolve();
+            },
+            send: function(channel, message) {
+                assert.equal(channel, expectedChannel, 'The message is sent using the right channel');
+                assert.equal(message, expectedMessage, 'The message is sent with the right content');
+                return Promise.resolve();
+            }
+        };
+
+        var expectedChannel = 'myChannel';
+        var expectedMessage = 'Hello';
+
+        proxyFactory.registerProvider('communicator', {
+            init: _.noop,
+            loadCommunicator: function() {
+                return expectedCommunicator;
+            }
+        });
+
+        var proxy = proxyFactory('communicator');
+
+        proxy.send(expectedChannel, expectedMessage).then(function() {
+            assert.ok(true, 'The message has been sent');
+            QUnit.start();
+        });
     });
 
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2583


Wrap the communicator into the proxy
Use a promise to get the communicator only when it is ready
Add error and receive events