### PR TITLE
Add the ability to set extra init params on runner proxy

### DIFF
--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -51,6 +51,17 @@ define([
         var delegateProxy, communicator, communicatorPromise;
 
         /**
+         * Gets parameters merged with extra parameters
+         * @param {Object} [params]
+         * @return {Object}
+         */
+        function getParams(params) {
+            var mergedParams = _.merge({}, params, extraCallParams);
+            extraCallParams = {};
+            return mergedParams;
+        }
+
+        /**
          * Gets the aggregated list of middlewares for a particular queue name
          * @param {String} queue - The name of the queue to get
          * @returns {Array}
@@ -162,8 +173,9 @@ define([
                  * @event proxy#init
                  * @param {Promise} promise
                  * @param {Object} config
+                 * @param {Object} params
                  */
-                return delegate('init', initConfig);
+                return delegate('init', initConfig, getParams());
             },
 
             /**
@@ -283,14 +295,16 @@ define([
             },
 
             /**
-             * Add extra parameters that will be added to the next callTestAction or callItemAction
+             * Add extra parameters that will be added to the init or the next callTestAction or callItemAction
              * This enables plugins to place parameters for next calls
              * @param {Object} params - the extra parameters
+             * @returns {proxy}
              */
             addCallActionParams : function addCallActionParams(params){
                 if(_.isPlainObject(params)){
                     _.merge(extraCallParams, params);
                 }
+                return this;
             },
 
             /**
@@ -342,18 +356,13 @@ define([
              * @fires callTestAction
              */
             callTestAction: function callTestAction(action, params) {
-
-                //merge extra parameters
-                var mergedParams = _.merge({}, params, extraCallParams);
-                extraCallParams = {};
-
                 /**
                  * @event proxy#callTestAction
                  * @param {Promise} promise
                  * @param {String} action
                  * @param {Object} params
                  */
-                return delegate('callTestAction', action, mergedParams);
+                return delegate('callTestAction', action, getParams(params));
             },
 
             /**
@@ -404,11 +413,6 @@ define([
              * @fires callItemAction
              */
             callItemAction: function callItemAction(uri, action, params) {
-
-                //merge extra parameters
-                var mergedParams = _.merge({}, params, extraCallParams);
-                extraCallParams = {};
-
                 /**
                  * @event proxy#callItemAction
                  * @param {Promise} promise
@@ -416,7 +420,7 @@ define([
                  * @param {String} action
                  * @param {Object} params
                  */
-                return delegate('callItemAction', uri, action, mergedParams);
+                return delegate('callItemAction', uri, action, getParams(params));
             },
 
             /**

--- a/views/js/test/runner/proxy/test.js
+++ b/views/js/test/runner/proxy/test.js
@@ -107,6 +107,35 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
     });
 
 
+    QUnit.asyncTest('proxyFactory.init with params', function(assert) {
+        var initConfig = {};
+        var initParams = {param1:"1", param2: 2};
+
+        QUnit.expect(8);
+        QUnit.stop();
+
+        proxyFactory.registerProvider('default', _.defaults({
+            init : function(config, params) {
+                assert.ok(true, 'The proxyFactory has delegated the call to init');
+                assert.equal(config, initConfig, 'The proxyFactory has provided the config object to the init method');
+                assert.deepEqual(params, initParams, 'The proxyFactory has provided the init params to the init method');
+                QUnit.start();
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        var result = proxyFactory('default', initConfig).on('init', function(promise, config, params) {
+            assert.ok(true, 'The proxyFactory has fired the "init" event');
+            assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "init" event');
+            assert.equal(config, initConfig, 'The proxyFactory has provided the config object through the "init" event');
+            assert.deepEqual(params, initParams, 'The proxyFactory has provided the init params through the "init" event');
+            QUnit.start();
+        }).addCallActionParams(initParams).init();
+
+        assert.ok(result instanceof Promise, 'The proxyFactory.init method has returned a promise');
+    });
+
+
     QUnit.asyncTest('proxyFactory.destroy', function(assert) {
         QUnit.expect(4);
         QUnit.stop();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2585

Handles extra parameters in the init step. This allows plugins to add init parameters before the runner starts.