### PR TITLE
Breaking/tao 2825 new plugin registry

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
 	'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '2.23.0',
+    'version' => '3.0.0',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
 	    'taoItems' => '>=2.6',
@@ -47,7 +47,10 @@ return array(
 	'install' => array(
 		'rdf' => array(
 				dirname(__FILE__). '/models/ontology/taotest.rdf'
-		),
+                            ),
+            'php' => [
+                'oat\\taoTests\\scripts\\install\\RegisterTestPluginService'
+            ]
 	),
 	'update' => "oat\\taoTests\\scripts\\update\\Updater",
 	'managementRole' => 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole',

--- a/models/classes/runner/plugins/PluginRegistry.php
+++ b/models/classes/runner/plugins/PluginRegistry.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ */
+namespace oat\taoTests\models\runner\plugins;
+
+use common_Logger;
+use common_ext_ExtensionsManager;
+use oat\oatbox\AbstractRegistry;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+
+/**
+ *
+ * Registry to store client library paths that will be provide to requireJs
+ *
+ */
+class PluginRegistry extends AbstractRegistry
+{
+    /**
+     * @see \oat\oatbox\AbstractRegistry::getConfigId()
+     */
+    protected function getConfigId()
+    {
+        return 'test_runner_plugin_registry';
+    }
+
+    /**
+     * @see \oat\oatbox\AbstractRegistry::getExtension()
+     */
+    protected function getExtension()
+    {
+        return common_ext_ExtensionsManager::singleton()->getExtensionById('taoTests');
+    }
+
+    public function register(TestPlugin $plugin)
+    {
+        if(!is_null($plugin)) {
+
+            $pluginData = json_decode(json_encode($plugin), true);
+
+            self::getRegistry()->set($plugin->getModule(),  $pluginData);
+
+            return true;
+        }
+        return false;
+    }
+
+    public function getPlugins()
+    {
+        self::getRegistry()->getMap();
+    }
+}

--- a/models/classes/runner/plugins/PluginRegistry.php
+++ b/models/classes/runner/plugins/PluginRegistry.php
@@ -56,7 +56,7 @@ class PluginRegistry extends AbstractRegistry
      */
     public function register(TestPlugin $plugin)
     {
-        if(!is_null($plugin) && ! empty($plugin->getModule) ) {
+        if(!is_null($plugin) && ! empty($plugin->getModule()) ) {
 
             //encode the plugin into an assoc array
             $pluginData = json_decode(json_encode($plugin), true);

--- a/models/classes/runner/plugins/PluginRegistry.php
+++ b/models/classes/runner/plugins/PluginRegistry.php
@@ -25,9 +25,11 @@ use oat\oatbox\AbstractRegistry;
 use oat\taoTests\models\runner\plugins\TestPlugin;
 
 /**
+ * Store the <b>available</b> test runner plugins, even if not activated,
+ * plugins have to be activated.
  *
- * Registry to store client library paths that will be provide to requireJs
  *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 class PluginRegistry extends AbstractRegistry
 {
@@ -47,10 +49,16 @@ class PluginRegistry extends AbstractRegistry
         return common_ext_ExtensionsManager::singleton()->getExtensionById('taoTests');
     }
 
+    /**
+     * Register a plugin
+     * @param TestPlugin $plugin the plugin to register
+     * @return boolean true if registered
+     */
     public function register(TestPlugin $plugin)
     {
-        if(!is_null($plugin)) {
+        if(!is_null($plugin) && ! empty($plugin->getModule) ) {
 
+            //encode the plugin into an assoc array
             $pluginData = json_decode(json_encode($plugin), true);
 
             self::getRegistry()->set($plugin->getModule(),  $pluginData);
@@ -58,10 +66,5 @@ class PluginRegistry extends AbstractRegistry
             return true;
         }
         return false;
-    }
-
-    public function getPlugins()
-    {
-        self::getRegistry()->getMap();
     }
 }

--- a/models/classes/runner/plugins/PluginRegistry.php
+++ b/models/classes/runner/plugins/PluginRegistry.php
@@ -59,7 +59,7 @@ class PluginRegistry extends AbstractRegistry
         if(!is_null($plugin) && ! empty($plugin->getModule()) ) {
 
             //encode the plugin into an assoc array
-            $pluginData = json_decode(json_encode($plugin), true);
+            $pluginData = $plugin->toArray();
 
             self::getRegistry()->set($plugin->getModule(),  $pluginData);
 

--- a/models/classes/runner/plugins/TestPlugin.php
+++ b/models/classes/runner/plugins/TestPlugin.php
@@ -142,6 +142,11 @@ class TestPlugin implements JsonSerializable
         return $this->category;
     }
 
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
     public function isActive()
     {
         return $this->active;

--- a/models/classes/runner/plugins/TestPlugin.php
+++ b/models/classes/runner/plugins/TestPlugin.php
@@ -172,6 +172,15 @@ class TestPlugin implements JsonSerializable
      */
     public function jsonSerialize()
     {
+        return $this->toArray();
+    }
+
+    /**
+     * Convenient method to convert the members to an assoc array
+     * @return array the data
+     */
+    public function toArray()
+    {
         return [
             'id'          => $this->id,
             'module'      => $this->module,

--- a/models/classes/runner/plugins/TestPlugin.php
+++ b/models/classes/runner/plugins/TestPlugin.php
@@ -19,37 +19,75 @@
  */
 namespace oat\taoTests\models\runner\plugins;
 
-use \JsonSerializable;
+use JsonSerializable;
+use common_exception_InconsistentData;
 
 /**
+ * A pojo that reprensents a test runner plugin.
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 class TestPlugin implements JsonSerializable
 {
 
+    /**
+     * @var string $id the plugin identifier
+     */
     private $id;
 
+    /**
+     * @var string $module the plugin AMD module
+     */
     private $module;
 
+    /**
+     * @var string|null $bundle the bundle the plugin belongs to
+     */
     private $bundle;
 
+    /**
+     * @var string|int|null $position to sort plugings together
+     */
     private $position;
 
+    /**
+     * @var string $description describes what the plugins is doing
+     */
     private $description = '';
 
+    /**
+     * @var string $name a human readable plugin name
+     */
     private $name = '';
 
+    /**
+     * @var boolean $active if the plugin is activated
+     */
     private $active = true;
 
+    /**
+     * @var string $category the plugin belongs to a category, to group them
+     */
     private $category;
 
+    /**
+     * @var string[] $tags tags to add labels to plugins
+     */
     private $tags = [];
 
 
-
+    /**
+     * Create a test plugin
+     * @param string $id the plugin identifier
+     * @param string $module the plugin AMD module
+     * @param string $category the category the plugin belongs to
+     * @param array $data optionnal other properties
+     */
     public function __construct ($id, $module, $category, $data = [] )
     {
+
+        self::validateRequiredData($id, $module, $category);
+
         $this->id          = (string)  $id;
         $this->module      = (string)  $module;
         $this->category    = (string)  $category;
@@ -70,7 +108,7 @@ class TestPlugin implements JsonSerializable
             $this->active = (boolean) $data['active'];
         }
         if(isset($data['tags'])) {
-            $this->tags = (boolean) $data['tags'];
+            $this->tags = (array) $data['tags'];
         }
     }
 
@@ -87,6 +125,11 @@ class TestPlugin implements JsonSerializable
     public function getBundle()
     {
         return $this->bundle;
+    }
+
+    public function getName()
+    {
+        return $this->name;
     }
 
     public function getDescription()
@@ -119,6 +162,9 @@ class TestPlugin implements JsonSerializable
         return in_array($this->tags, $tag);
     }
 
+    /**
+     * @see JsonSerializable::jsonSerialize
+     */
     public function jsonSerialize()
     {
         return [
@@ -134,8 +180,45 @@ class TestPlugin implements JsonSerializable
         ];
     }
 
-    public static function fromArray( array $data ) 
+    /**
+     * Create a test plugin from an assoc array
+     * @param array $data
+     * @return TestPlugin the new instance
+     * @throws common_exception_InconsistentData
+     */
+    public static function fromArray( array $data )
     {
-        return new self($data['id'], $data['module'], $data['category'], $data);
+
+        if( !isset($data['id']) || !isset($data['module']) || !isset($data['category']) ) {
+            throw new common_exception_InconsistentData('The plugin requires an id, a module and a category');
+        }
+        if(self::validateRequiredData($data['id'], $data['module'], $data['category'])){
+            return new self($data['id'], $data['module'], $data['category'], $data);
+        }
+        return null;
+    }
+
+    /**
+     * Validate required data to construct a plugin
+     * @param mixed $id
+     * @param mixed $module
+     * @param mixed $category
+     * @return boolean true
+     * @throws common_exception_InconsistentData
+     */
+    private static function validateRequiredData($id, $module, $category)
+    {
+
+        if(! is_string($id) || empty($id)) {
+            throw new common_exception_InconsistentData('The plugin needs an id');
+        }
+        if(! is_string($module) || empty($module)) {
+            throw new common_exception_InconsistentData('The plugin needs a module');
+        }
+        if(! is_string($category) || empty($category)) {
+            throw new common_exception_InconsistentData('The plugin needs a category');
+        }
+
+        return true;
     }
 }

--- a/models/classes/runner/plugins/TestPlugin.php
+++ b/models/classes/runner/plugins/TestPlugin.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ */
+namespace oat\taoTests\models\runner\plugins;
+
+use \JsonSerializable;
+
+/**
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class TestPlugin implements JsonSerializable
+{
+
+    private $id;
+
+    private $module;
+
+    private $bundle;
+
+    private $position;
+
+    private $description = '';
+
+    private $name = '';
+
+    private $active = true;
+
+    private $category;
+
+    private $tags = [];
+
+
+
+    public function __construct ($id, $module, $category, $data = [] )
+    {
+        $this->id          = (string)  $id;
+        $this->module      = (string)  $module;
+        $this->category    = (string)  $category;
+
+        if(isset($data['bundle'])) {
+            $this->bundle  = (string)  $data['bundle'];
+        }
+        if(isset($data['position'])) {
+            $this->position  = $data['position'];
+        }
+        if(isset($data['description'])) {
+            $this->description  = (string) $data['description'];
+        }
+        if(isset($data['name'])) {
+            $this->name  = (string) $data['name'];
+        }
+        if(isset($data['active'])) {
+            $this->active = (boolean) $data['active'];
+        }
+        if(isset($data['tags'])) {
+            $this->tags = (boolean) $data['tags'];
+        }
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getModule()
+    {
+        return $this->module;
+    }
+
+    public function getBundle()
+    {
+        return $this->bundle;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getCategory()
+    {
+        return $this->category;
+    }
+
+    public function isActive()
+    {
+        return $this->active;
+    }
+
+    public function setActive($active)
+    {
+        $this->active = (boolean) $active;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public function hasTag($tag)
+    {
+        return in_array($this->tags, $tag);
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'id'          => $this->id,
+            'module'      => $this->module,
+            'bundle'      => $this->bundle,
+            'position'    => $this->position,
+            'name'        => $this->name,
+            'description' => $this->description,
+            'category'    => $this->category,
+            'active'      => $this->active,
+            'tags'        => $this->tags
+        ];
+    }
+
+    public static function fromArray( array $data ) 
+    {
+        return new self($data['id'], $data['module'], $data['category'], $data);
+    }
+}

--- a/models/classes/runner/plugins/TestPlugin.php
+++ b/models/classes/runner/plugins/TestPlugin.php
@@ -197,10 +197,7 @@ class TestPlugin implements JsonSerializable
         if( !isset($data['id']) || !isset($data['module']) || !isset($data['category']) ) {
             throw new common_exception_InconsistentData('The plugin requires an id, a module and a category');
         }
-        if(self::validateRequiredData($data['id'], $data['module'], $data['category'])){
-            return new self($data['id'], $data['module'], $data['category'], $data);
-        }
-        return null;
+        return new self($data['id'], $data['module'], $data['category'], $data);
     }
 
     /**

--- a/models/classes/runner/plugins/TestPluginService.php
+++ b/models/classes/runner/plugins/TestPluginService.php
@@ -19,12 +19,14 @@
  */
 namespace oat\taoTests\models\runner\plugins;
 
-use oat\oatbox\service\ConfigurableService;
 use core_kernel_classes_Resource;
+use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\service\ServiceManager;
 use tao_models_classes_service_ConstantParameter as ConstantParameter;
 use tao_models_classes_service_ServiceCall as ServiceCall;
+
 /**
+ * Manage test plugins
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
@@ -33,6 +35,9 @@ class TestPluginService extends ConfigurableService
 
     const CONFIG_ID = 'taoTests/TestPlugin';
 
+    /**
+     * @var PluginRegistry
+     */
     private $registry;
 
     public function __construct()
@@ -40,6 +45,11 @@ class TestPluginService extends ConfigurableService
         $this->registry = PluginRegistry::getRegistry();
     }
 
+    /**
+     * Retrieve the list of all available plugins (from the registry)
+     *
+     * @return TestPlugin[] the avaialble plugins
+     */
     public function getAllPlugins()
     {
         return array_map(function($value) {
@@ -47,6 +57,12 @@ class TestPluginService extends ConfigurableService
         }, $this->registry->getMap());
     }
 
+    /**
+     * Retrieve the given plugin from the registry
+     *
+     * @param string $id the identifier of the plugin to retrieve
+     * @return TestPlugin|null the plugin
+     */
     public function getPlugin($id)
     {
         foreach($this->registry->getMap() as $plugin){
@@ -57,14 +73,28 @@ class TestPluginService extends ConfigurableService
         return null;
     }
 
+    /**
+     * Change the state of a plugin to active
+     *
+     * @param TestPlugin $plugin the plugin to activate
+     * @return boolean true if activated
+     */
     public function activatePlugin(TestPlugin $plugin)
     {
         if(!is_null($plugin)){
             $plugin->setActive(true);
-            $this->registry->register($plugin);
+            return $this->registry->register($plugin);
         }
+
+        return false;
     }
 
+    /**
+     * Change the state of a plugin to inactive
+     *
+     * @param TestPlugin $plugin the plugin to deactivate
+     * @return boolean true if deactivated
+     */
     public function deactivatePlugin(TestPlugin $plugin)
     {
         if(!is_null($plugin)){
@@ -73,9 +103,12 @@ class TestPluginService extends ConfigurableService
         }
     }
 
+    /**
+     * Registry setter
+     * @param PlguinRegistry $registry
+     */
     public function setRegistry(PluginRegistry $registry)
     {
         $this->registry = $registry;
     }
-
 }

--- a/models/classes/runner/plugins/TestPluginService.php
+++ b/models/classes/runner/plugins/TestPluginService.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ */
+namespace oat\taoTests\models\runner\plugins;
+
+use oat\oatbox\service\ConfigurableService;
+use core_kernel_classes_Resource;
+use oat\oatbox\service\ServiceManager;
+use tao_models_classes_service_ConstantParameter as ConstantParameter;
+use tao_models_classes_service_ServiceCall as ServiceCall;
+/**
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class TestPluginService extends ConfigurableService
+{
+
+    const CONFIG_ID = 'taoTests/TestPlugin';
+
+    private $registry;
+
+    public function __construct()
+    {
+        $this->registry = PluginRegistry::getRegistry();
+    }
+
+    public function getAllPlugins()
+    {
+        return array_map(function($value) {
+          return TestPlugin::fromArray($value);
+        }, $this->registry->getMap());
+    }
+
+    public function getPlugin($id)
+    {
+        foreach($this->registry->getMap() as $plugin){
+            if($plugin['id'] == $id){
+                return TestPlugin::fromArray($plugin);
+            }
+        }
+        return null;
+    }
+
+    public function activatePlugin(TestPlugin $plugin)
+    {
+        if(!is_null($plugin)){
+            $plugin->setActive(true);
+            $this->registry->register($plugin);
+        }
+    }
+
+    public function deactivatePlugin(TestPlugin $plugin)
+    {
+        if(!is_null($plugin)){
+            $plugin->setActive(false);
+            $this->registry->register($plugin);
+        }
+    }
+
+    public function setRegistry(PluginRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+}

--- a/models/classes/runner/plugins/TestPluginService.php
+++ b/models/classes/runner/plugins/TestPluginService.php
@@ -52,9 +52,13 @@ class TestPluginService extends ConfigurableService
      */
     public function getAllPlugins()
     {
-        return array_map(function($value) {
-          return TestPlugin::fromArray($value);
+        $plugins = array_map(function($value) {
+            return $this->loadPlugin($value);
         }, $this->registry->getMap());
+
+        return array_filter($plugins, function($plugin){
+            return !is_null($plugin);
+        });
     }
 
     /**
@@ -67,10 +71,26 @@ class TestPluginService extends ConfigurableService
     {
         foreach($this->registry->getMap() as $plugin){
             if($plugin['id'] == $id){
-                return TestPlugin::fromArray($plugin);
+                return $this->loadPlugin($plugin);
             }
         }
         return null;
+    }
+
+    /**
+     * Load a test plugin from the given data
+     * @param array $data
+     * @return TestPlugin|null
+     */
+    private function loadPlugin(array $data)
+    {
+        $plugin = null;
+        try {
+            $plugin = TestPlugin::fromArray($data);
+        } catch(\common_exception_InconsistentData $dataException) {
+            \common_Logger::w('Got inconsistent plugin data, skipping.');
+        }
+        return $plugin;
     }
 
     /**

--- a/scripts/install/RegisterTestPluginService.php
+++ b/scripts/install/RegisterTestPluginService.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+namespace oat\taoTests\scripts\install;
+
+use oat\taoTests\models\runner\plugins\TestPluginService;
+use oat\oatbox\service\ServiceManager;
+
+/**
+ */
+class RegisterTestPluginService extends \common_ext_action_InstallAction
+{
+    /**
+     * @param $params
+     */
+    public function __invoke($params)
+    {
+        $serviceManager = ServiceManager::getServiceManager();
+
+        $testPluginService = new TestPluginService();
+        $testPluginService->setServiceManager($serviceManager);
+        $serviceManager->register(TestPluginService::CONFIG_ID, $testPluginService);
+    }
+}
+

--- a/scripts/install/RegisterTestPluginService.php
+++ b/scripts/install/RegisterTestPluginService.php
@@ -25,6 +25,9 @@ use oat\taoTests\models\runner\plugins\TestPluginService;
 use oat\oatbox\service\ServiceManager;
 
 /**
+ * Installation action that registers the TestPluginService
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 class RegisterTestPluginService extends \common_ext_action_InstallAction
 {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -47,7 +47,9 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.7.1');
         }
 
-        if ($this->isVersion('2.7.1')){
+        $this->skip('2.7.1', '2.23.0');
+
+        if ($this->isVersion('2.23.0')){
 
             //register test plugin service
             $registerService = new RegisterTestPluginService();

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -21,31 +21,39 @@
 
 namespace oat\taoTests\scripts\update;
 
+use oat\taoTests\scripts\install\RegisterTestPluginService;
 
-class Updater extends \common_ext_ExtensionUpdater 
+class Updater extends \common_ext_ExtensionUpdater
 {
-	/**
-     * 
+        /**
+     *
      * @param string $currentVersion
      * @return string $versionUpdatedTo
      */
     public function update($initialVersion)
     {
-        
+
         if ($this->isBetween('0', '2.7')){
             $this->setVersion('2.7');
         }
-		// remove active prop
-		if ($this->isVersion('2.7')){
-		    $deprecatedProperty = new \core_kernel_classes_Property('http://www.tao.lu/Ontologies/TAOTest.rdf#active');
-		    $iterator = new \core_kernel_classes_ResourceIterator(array(\taoTests_models_classes_TestsService::singleton()->getRootClass()));
-		    foreach ($iterator as $resource) {
-		        $resource->removePropertyValues($deprecatedProperty);
-		    }
-		    $this->setVersion('2.7.1');
-		}
 
-        $this->skip('2.7.1', '2.23.0');
+        // remove active prop
+        if ($this->isVersion('2.7')){
+            $deprecatedProperty = new \core_kernel_classes_Property('http://www.tao.lu/Ontologies/TAOTest.rdf#active');
+            $iterator = new \core_kernel_classes_ResourceIterator(array(\taoTests_models_classes_TestsService::singleton()->getRootClass()));
+            foreach ($iterator as $resource) {
+                $resource->removePropertyValues($deprecatedProperty);
+            }
+            $this->setVersion('2.7.1');
+        }
 
-	}
+        if ($this->isVersion('2.7.1')){
+
+            //register test plugin service
+            $registerService = new RegisterTestPluginService();
+            $registerService([]);
+
+            $this->setVersion('3.0.0');
+        }
+    }
 }

--- a/test/runner/plugins/TestPluginServiceTest.php
+++ b/test/runner/plugins/TestPluginServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ */
+namespace oat\taoTests\test\runner\plugins;
+
+use common_exception_InconsistentData;
+use oat\taoTests\models\runner\plugins\PluginRegistry;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+use oat\taoTests\models\runner\plugins\TestPluginService;
+use oat\tao\test\TaoPhpUnitTestRunner;
+use Prophecy\Prophet;
+use oat\oatbox\service\ConfigurableService;
+
+/**
+ * Test the TestPluginService
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class TestPluginServiceTest extends TaoPhpUnitTestRunner
+{
+
+    //data to stub the regsitry content
+    const PLUGIN_DATA =  [
+        'taoQtiTest/runner/plugins/controls/title/title' => [
+                'id' => 'title',
+                'module' => 'taoQtiTest/runner/plugins/controls/title/title',
+                'bundle' => 'plugins/bundle.min',
+                'position' => 1,
+                'name' => 'Title indicator',
+                'description' => 'Display the title of current test element',
+                'category' => 'controls',
+                'active' => true,
+                'tags' => ['core', 'qti' ]
+            ],
+            'taoQtiTest/runner/plugins/controls/timer/timer' => [
+                'id' => 'timer',
+                'module' => 'taoQtiTest/runner/plugins/controls/timer/timer',
+                'bundle' => 'plugins/bundle.min',
+                'position' => 2,
+                'name' => 'Timer indicator',
+                'description' => 'Add countdown when remaining time',
+                'category' => 'controls',
+                'active' => true,
+                'tags' => ['core' ]
+            ]
+        ];
+
+    /**
+     * Get the service with the stubbed registry
+     * @return TestPluginService
+     */
+    protected function getTestPluginService()
+    {
+        $testPluginService = new TestPluginService();
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize();
+        $prophecy->willExtend(PluginRegistry::class);
+        $prophecy->getMap()->willReturn(self::PLUGIN_DATA);
+
+        $testPluginService->setRegistry($prophecy->reveal());
+
+        return $testPluginService;
+    }
+
+    /**
+     * Check the service is a service
+     */
+    public function testApi()
+    {
+        $testPluginService = $this->getTestPluginService();
+        $this->assertInstanceOf(TestPluginService::class, $testPluginService);
+        $this->assertInstanceOf(ConfigurableService::class, $testPluginService);
+    }
+
+    /**
+     * Test the method TestPluginService::getAllPlugins
+     */
+    public function testGetAllPlugins()
+    {
+        $testPluginService = $this->getTestPluginService();
+
+        $plugins = $testPluginService->getAllPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $plugin0 = $plugins['taoQtiTest/runner/plugins/controls/title/title'];
+        $plugin1 = $plugins['taoQtiTest/runner/plugins/controls/timer/timer'];
+
+        $this->assertInstanceOf(TestPlugin::class, $plugin0);
+        $this->assertInstanceOf(TestPlugin::class, $plugin1);
+
+        $this->assertEquals('title', $plugin0->getId());
+        $this->assertEquals('timer', $plugin1->getId());
+
+        $this->assertEquals('Title indicator', $plugin0->getName());
+        $this->assertEquals('Timer indicator', $plugin1->getName());
+
+        $this->assertEquals(1, $plugin0->getPosition());
+        $this->assertEquals(2, $plugin1->getPosition());
+
+        $this->assertTrue($plugin0->isActive());
+        $this->assertTrue($plugin1->isActive());
+    }
+
+    /**
+     * Test the method TestPluginService::getPlugin
+     */
+    public function testGetOnePlugin()
+    {
+        $testPluginService = $this->getTestPluginService();
+
+        $plugin = $testPluginService->getPlugin('timer');
+
+        $this->assertInstanceOf(TestPlugin::class, $plugin);
+        $this->assertEquals('timer', $plugin->getId());
+        $this->assertEquals('Timer indicator', $plugin->getName());
+        $this->assertEquals(2, $plugin->getPosition());
+        $this->assertEquals('taoQtiTest/runner/plugins/controls/timer/timer', $plugin->getModule());
+        $this->assertEquals('controls', $plugin->getCategory());
+
+        $this->assertTrue($plugin->isActive());
+    }
+
+}

--- a/test/runner/plugins/TestPluginTest.php
+++ b/test/runner/plugins/TestPluginTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ */
+namespace oat\taoTests\test\runner\plugins;
+
+use Prophecy\Argument;
+use Prophecy\Prophet;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+use oat\tao\test\TaoPhpUnitTestRunner;
+
+/**
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class TestPluginTest extends TaoPhpUnitTestRunner
+{
+
+    public function accessorsProvider()
+    {
+        return [
+            [
+                [
+                    'id'          => 'foo',
+                    'name'        => 'Foo',
+                    'description' => 'The best foo ever',
+                    'active'      => true,
+                    'tags'        => ['required']
+                ], [
+                    'id'          => 'foo',
+                    'name'        => 'Foo',
+                    'description' => 'The best foo ever',
+                    'active'      => true,
+                    'tags'        => ['required']
+                ]
+            ], [
+                [
+                    'id'          => 12,
+                    'name'        => 21,
+                ], [
+                    'id'          => '12',
+                    'name'        => '21',
+                    'description' => '',
+                    'active'      => true,
+                    'tags'        => []
+                ]
+            ], [
+                [
+                    'id'          => null,
+                    'name'        => null,
+                    'description' => null,
+                    'active'      => null,
+                    'tags'        => null
+                ], [
+                    'id'          => '',
+                    'name'        => '',
+                    'description' => '',
+                    'active'      => true,
+                    'tags'        => []
+                ]
+            ]
+        ];
+    }
+
+    /**
+     *
+     * @dataProvider accessorsProvider
+     */
+    public function testAccessors($input, $output)
+    {
+
+        if(isset($input['description'])){
+            $testPlugin = new TestPlugin($input['id'], $input['name'], $input['description'], $input['active'], $input['tags']);
+        } else {
+            $testPlugin = new TestPlugin($input['id'], $input['name']);
+        }
+
+        $this->assertEquals($output['id'], $testPlugin->getId());
+        $this->assertEquals($output['name'], $testPlugin->getName());
+        $this->assertEquals($output['description'], $testPlugin->getDescription());
+        $this->assertEquals($output['active'], $testPlugin->isActive());
+        $this->assertEquals($output['tags'], $testPlugin->getTags());
+
+        $testPlugin->setActive(!$output['active']);
+        $this->assertEquals(!$output['active'], $testPlugin->isActive());
+    }
+
+
+    public function testJsonSerialize()
+    {
+        $expected = '{"id":"bar","name":"Bar","description":"The best bar ever","active":false,"tags":["dummy","goofy"]}';
+
+        $testPlugin = new TestPlugin('bar', 'Bar', 'The best bar ever', false, ['dummy', 'goofy']);
+
+        $serialized = json_encode($testPlugin);
+
+        $this->assertEquals($expected, $serialized);
+    }
+}

--- a/test/runner/plugins/TestPluginTest.php
+++ b/test/runner/plugins/TestPluginTest.php
@@ -24,12 +24,17 @@ use oat\taoTests\models\runner\plugins\TestPlugin;
 use oat\tao\test\TaoPhpUnitTestRunner;
 
 /**
+ * Test the TestPlugin pojo
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 class TestPluginTest extends TaoPhpUnitTestRunner
 {
 
+    /**
+     * Data provider
+     * @return array the data
+     */
     public function accessorsProvider()
     {
         return [
@@ -169,7 +174,9 @@ class TestPluginTest extends TaoPhpUnitTestRunner
         $this->assertEquals(!$output['active'], $testPlugin->isActive());
     }
 
-
+    /**
+     * Test encoding the object to json
+     */
     public function testJsonSerialize()
     {
         $expected = '{"id":"bar","module":"bar\/bar","bundle":"plugins\/bundle.min","position":12,"name":"Bar","description":"The best bar ever","category":"dummy","active":false,"tags":["dummy","goofy"]}';


### PR DESCRIPTION
Move the concept of plugins a step higher.
The registry is now held by taoTests, contains more infos and isn't a ClientConfig anymore. 
The reason is to enable to start a DelvieryContainer with _some_ plugins. 