### PR TITLE
Feature/tao 2853 proxy init params

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
 	'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '3.2.0',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
 	    'taoItems' => '>=2.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -58,6 +58,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.0.0');
         }
 
-        $this->skip('3.0.0', '3.1.0');
+        $this->skip('3.0.0', '3.2.0');
 	}
 }

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -172,18 +172,19 @@ define([
 
             /**
              * Initializes the proxy
+             * @param {Object} [params] - An optional list of parameters
              * @returns {Promise} - Returns a promise. The proxy will be fully initialized on resolve.
              *                      Any error will be provided if rejected.
              * @fires init
              */
-            init: function init() {
+            init: function init(params) {
                 /**
                  * @event proxy#init
                  * @param {Promise} promise
                  * @param {Object} config
                  * @param {Object} params
                  */
-                return delegate('init', initConfig, getParams());
+                return delegate('init', initConfig, getParams(params));
             },
 
             /**
@@ -200,7 +201,7 @@ define([
                 return delegate('destroy').then(function() {
                     // The proxy is now destroyed. A call to init() is mandatory to be able to use it again.
                     initialized = false;
-                    
+
                     // a communicator has been invoked and...
                     if (communicatorPromise) {
                         return new Promise(function(resolve, reject) {

--- a/views/js/test/runner/proxy/test.js
+++ b/views/js/test/runner/proxy/test.js
@@ -84,14 +84,18 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
 
     QUnit.asyncTest('proxyFactory.init', function(assert) {
         var initConfig = {};
+        var expectedParams = {
+            storeId: '342FEEF6-ECA0-418E-81E3-4E6F7D1F90E4'
+        };
 
-        QUnit.expect(6);
+        QUnit.expect(7);
         QUnit.stop();
 
         proxyFactory.registerProvider('default', _.defaults({
-            init : function(config) {
+            init : function(config, params) {
                 assert.ok(true, 'The proxyFactory has delegated the call to init');
                 assert.equal(config, initConfig, 'The proxyFactory has provided the config object to the init method');
+                assert.deepEqual(params, expectedParams, 'The delegated method received the expected params');
                 QUnit.start();
                 return Promise.resolve();
             }
@@ -102,7 +106,7 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
             assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "init" event');
             assert.equal(config, initConfig, 'The proxyFactory has provided the config object through the "init" event');
             QUnit.start();
-        }).init();
+        }).init(expectedParams);
 
         assert.ok(result instanceof Promise, 'The proxyFactory.init method has returned a promise');
     });
@@ -110,7 +114,11 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
 
     QUnit.asyncTest('proxyFactory.init with params', function(assert) {
         var initConfig = {};
-        var initParams = {param1:"1", param2: 2};
+        var extraParams = {param1:"1", param2: 2};
+        var initParams = {
+            storeId: '342FEEF6-ECA0-418E-81E3-4E6F7D1F90E4'
+        };
+        var expectedParams = _.merge({}, initParams, extraParams);
 
         QUnit.expect(8);
         QUnit.stop();
@@ -119,7 +127,7 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
             init : function(config, params) {
                 assert.ok(true, 'The proxyFactory has delegated the call to init');
                 assert.equal(config, initConfig, 'The proxyFactory has provided the config object to the init method');
-                assert.deepEqual(params, initParams, 'The proxyFactory has provided the init params to the init method');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the init params to the init method');
                 QUnit.start();
                 return Promise.resolve();
             }
@@ -129,9 +137,9 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
             assert.ok(true, 'The proxyFactory has fired the "init" event');
             assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "init" event');
             assert.equal(config, initConfig, 'The proxyFactory has provided the config object through the "init" event');
-            assert.deepEqual(params, initParams, 'The proxyFactory has provided the init params through the "init" event');
+            assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the init params through the "init" event');
             QUnit.start();
-        }).addCallActionParams(initParams).init();
+        }).addCallActionParams(extraParams).init(initParams);
 
         assert.ok(result instanceof Promise, 'The proxyFactory.init method has returned a promise');
     });
@@ -316,8 +324,8 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
             assert.ok(result instanceof Promise, 'The proxyFactory.sendVariables method has returned a promise');
         });
     });
-    
-    
+
+
     QUnit.asyncTest('proxyFactory.callTestAction', function(assert) {
         var expectedAction = 'test';
         var expectedParams = {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2853

The proxy can now be initialized with parameters