### PR TITLE
Feature/tao 3251 runner registry

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '3.5.1',
+    'version' => '3.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -70,6 +70,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.5.0');
         }
         
-        $this->skip('3.5.0', '3.5.1');
+        $this->skip('3.5.0', '3.6.0');
 	}
 }

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -380,6 +380,8 @@ define([
                     loader = 'load' + name.charAt(0).toUpperCase() + name.substr(1);
                     if(_.isFunction(provider[loader])){
                         registry[name] = provider[loader].call(runner);
+                    } else {
+                        registry[name] = null;
                     }
                 }
                 return registry[name];

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -67,6 +67,11 @@ define([
         var plugins        = {};
 
         /**
+         * @type {Object} registry for some inner values
+         */
+        var registry       = {};
+
+        /**
          * @type {Object} the test of the runner
          */
         var states = {
@@ -88,23 +93,10 @@ define([
         var provider  = testRunnerFactory.getProvider(providerName);
 
         /**
-         * Keep the area broker instance
-         * @see taoTests/runner/areaBroker
-         */
-        var areaBroker;
-
-        /**
          * Keep the proxy instance
          * @see taoTests/runner/proxy
          */
         var proxy;
-
-
-        /**
-         * Keep the instance of the probes overseer
-         * @see taoTests/runner/probeOverseer
-         */
-        var probeOverseer;
 
         /**
          * Run a method of the provider (by delegation)
@@ -368,12 +360,29 @@ define([
 
                         return destroyed.then(function() {
                             testContext = {};
+                            registry = {};
                             self.setState('destroy', true)
                                 .trigger('destroy');
                         });
                     }).catch(reportError);
                 }).catch(reportError);
                 return this;
+            },
+
+            /**
+             * Reads a value from the registry. If the value has not been set, requests the provider to seed the value.
+             * @param {String} name - The name of the value to read
+             * @returns {*}
+             */
+            getRegistry : function getRegistry(name) {
+                var loader;
+                if ('undefined' === typeof(registry[name])) {
+                    loader = 'load' + name.charAt(0).toUpperCase() + name.substr(1);
+                    if(_.isFunction(provider[loader])){
+                        registry[name] = provider[loader].call(runner);
+                    }
+                }
+                return registry[name];
             },
 
             /**
@@ -407,12 +416,8 @@ define([
              * @returns {areaBroker} the areaBroker
              */
             getAreaBroker : function getAreaBroker(){
-                if(!areaBroker){
-                    areaBroker = provider.loadAreaBroker.call(this);
-                }
-                return areaBroker;
+                return this.getRegistry('areaBroker');
             },
-
 
             /**
              * Get the proxy, load it if not present
@@ -440,11 +445,7 @@ define([
              * @returns {probeOverseer} the probe overseer
              */
             getProbeOverseer : function getProbeOverseer(){
-                if(!probeOverseer && _.isFunction(provider.loadProbeOverseer)){
-                    probeOverseer = provider.loadProbeOverseer.call(this);
-                }
-
-                return probeOverseer;
+                return this.getRegistry('probeOverseer');
             },
 
             /**
@@ -482,11 +483,10 @@ define([
              * @returns {Boolean} if active, false if not set
              */
             getPersistentState : function getPersistentState(name) {
-                var getPersistentState = provider.getPersistentState;
                 var state;
 
-                if(_.isFunction(getPersistentState)){
-                    state = getPersistentState.call(runner, name);
+                if(_.isFunction(provider.getPersistentState)){
+                    state = provider.getPersistentState.call(runner, name);
                 }
 
                 return !!state;

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -837,12 +837,13 @@ define([
     });
 
     QUnit.test('registry', function(assert) {
-        QUnit.expect(2);
-
         var expectedValue = {
             init: function(){},
             destroy: function() {}
         };
+        var runner;
+
+        QUnit.expect(3);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker : function(){
@@ -855,9 +856,9 @@ define([
             init : function init(){}
         });
 
-        var myValue = runnerFactory('foo').getRegistry('myValue');
-
-        assert.equal(myValue, expectedValue, 'The right myValue has been provided');
+        runner = runnerFactory('foo');;
+        assert.equal(runner.getRegistry('myValue'), expectedValue, 'The right myValue has been provided');
+        assert.equal(runner.getRegistry('ubknown'), null, 'The unknown values are seeded to null');
     });
 
     QUnit.test('no loadProxy', function(assert) {

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -65,6 +65,7 @@ define([
         {name : 'disableItem', title : 'disableItem'},
         {name : 'enableItem', title : 'enableItem'},
 
+        {name : 'getRegistry', title : 'getRegistry'},
         {name : 'getPlugins', title : 'getPlugins'},
         {name : 'getPlugin', title : 'getPlugin'},
         {name : 'getConfig', title : 'getConfig'},
@@ -833,6 +834,30 @@ define([
         var probeOverseer = runnerFactory('foo').getProbeOverseer();
 
         assert.equal(probeOverseer, expectedProbeOverseer, 'The right probeOverseer has been provided');
+    });
+
+    QUnit.test('registry', function(assert) {
+        QUnit.expect(2);
+
+        var expectedValue = {
+            init: function(){},
+            destroy: function() {}
+        };
+
+        runnerFactory.registerProvider('foo', {
+            loadAreaBroker : function(){
+                return {};
+            },
+            loadMyValue: function() {
+                assert.ok(true, 'The loadMyValue method has been called');
+                return expectedValue;
+            },
+            init : function init(){}
+        });
+
+        var myValue = runnerFactory('foo').getRegistry('myValue');
+
+        assert.equal(myValue, expectedValue, 'The right myValue has been provided');
     });
 
     QUnit.test('no loadProxy', function(assert) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3251

Add a registry feature on the test runner abstraction.

The goal is to ease the extendability of the runner by allowing to seed a registry through the loadXxx() methods:

```javascript
var something  = runner.getRegistry('something');
```

This will be translated internally to something like:

```javascript
if (!registry['something']) {
    if (provider.loadSomething) {
         registry['something'] = provider.loadSomething.call(runner);
    }
}
return registry['something'];
```

Thanks to this feature the provider will be able to seamlessly aggregate new internal components without having to request an API change in the abstraction.