### PR TITLE
Fix/probe double end latencies

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '3.7.1',
+    'version' => '3.7.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -77,6 +77,6 @@ class Updater extends \common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('3.6.0');
         }
-        $this->skip('3.6.0', '3.7.1');
+        $this->skip('3.6.0', '3.7.2');
 	}
 }

--- a/views/js/runner/probeOverseer.js
+++ b/views/js/runner/probeOverseer.js
@@ -80,7 +80,7 @@ define([
             var probeHandler = function probeHandler(){
                 var now = moment();
                 var data = {
-                    id   : uuid(8, 16),
+                    id   : uuid(12, 16),
                     type : probe.name,
                     timestamp : now.format('x') / 1000,
                     timezone  : now.tz(timeZone).format('Z')
@@ -110,7 +110,7 @@ define([
             var startHandler = function startHandler(){
                 var now = moment();
                 var data = {
-                    id: uuid(8, 16),
+                    id: uuid(12, 16),
                     marker: 'start',
                     type : probe.name,
                     timestamp : now.format('x') / 1000,
@@ -135,7 +135,7 @@ define([
                 var args = slice.call(arguments);
 
                 last = _.findLast(immutableQueue, { type : probe.name, marker : 'start' });
-                if(last && !_.findLast(immutableQueue, { type : probe.name, marker : 'stop', id : last.id })){
+                if(last && !_.findLast(immutableQueue, { type : probe.name, marker : 'end', id : last.id })){
                     data.id = last.id;
                     data.marker = 'end';
                     if(typeof probe.capture === 'function'){
@@ -293,7 +293,6 @@ define([
              * @returns {Promise} with the data in parameter
              */
             flush: function flush(){
-                var self = this;
                 return getStorage().then(function(storage){
                     return new Promise(function(resolve){
                         Promise.all(writing).then(function () {
@@ -302,7 +301,7 @@ define([
                                 queue = [];
                                 return storage.setItem('queue', queue).then(function(){
                                     resolve(flushed);
-                               });
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
 - increase size of ids to prevent them to collide (unlikely to happen but it's safer)
 - prevent to store the same end event twice (only the first matter)