### PR TITLE
Feature/tao 3942 pause message

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '3.8.0',
+    'version' => '3.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -34,7 +34,6 @@ class Updater extends \common_ext_ExtensionUpdater
      */
     public function update($initialVersion)
     {
-
         if ($this->isBetween('0', '2.7')){
             $this->setVersion('2.7');
         }
@@ -77,6 +76,7 @@ class Updater extends \common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('3.6.0');
         }
-        $this->skip('3.6.0', '3.8.0');
+        
+        $this->skip('3.6.0', '3.9.0');
 	}
 }

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -49,7 +49,7 @@ define([
         var tokenHandler    = tokenHandlerFactory();
         var middlewares     = {};
         var initialized     = false;
-        var delegateProxy, communicator, communicatorPromise;
+        var proxy, delegateProxy, communicator, communicatorPromise;
 
         /**
          * Gets parameters merged with extra parameters
@@ -148,9 +148,9 @@ define([
 
         /**
          * Defines the test runner proxy
-         * @type {proxy}
+         * @typedef {proxy}
          */
-        var proxy = eventifier({
+        proxy = eventifier({
             /**
              * Add a middleware
              * @param {String} [command] The command queue in which add the middleware (default: 'all')
@@ -162,9 +162,9 @@ define([
                 var list = middlewares[queue] || [];
                 middlewares[queue] = list;
 
-                _.each(arguments, function(callback) {
-                    if (_.isFunction(callback)) {
-                        list.push(callback);
+                _.each(arguments, function(cb) {
+                    if (_.isFunction(cb)) {
+                        list.push(cb);
                     }
                 });
                 return this;
@@ -304,8 +304,8 @@ define([
                 }
 
                 this.getCommunicator()
-                    .then(function(communicator) {
-                        communicator.channel(name, handler);
+                    .then(function(communicatorInstance) {
+                        communicatorInstance.channel(name, handler);
                     })
                     // just an empty catch to avoid any error to be displayed in the console when the communicator is not enabled
                     .catch(_.noop);
@@ -323,8 +323,8 @@ define([
              */
             send: function send(channel, message) {
                 return this.getCommunicator()
-                    .then(function(communicator) {
-                        return communicator.send(channel, message);
+                    .then(function(communicatorInstance) {
+                        return communicatorInstance.send(channel, message);
                     });
             },
 

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -295,12 +295,23 @@ define([
              * @throws TypeError if the name is missing or the handler is not a callback
              */
             channel: function channel(name, handler) {
+                if (!_.isString(name) || name.length <= 0) {
+                    throw new TypeError('A channel must have a name');
+                }
+
+                if (!_.isFunction(handler)) {
+                    throw new TypeError('A handler must be attached to a channel');
+                }
+
                 this.getCommunicator()
                     .then(function(communicator) {
                         communicator.channel(name, handler);
                     })
                     // just an empty catch to avoid any error to be displayed in the console when the communicator is not enabled
                     .catch(_.noop);
+
+                this.on('channel-' + name, handler);
+
                 return this;
             },
 
@@ -481,6 +492,25 @@ define([
                 return delegate('telemetry', uri, signal, params);
             }
         });
+
+        // catch platform messages that come outside of the communicator component, then each is dispatched to the right channel
+        proxy
+            .on('message', function (channel, message) {
+                this.trigger('channel-' + channel, message);
+            })
+            .use(function(request, response, next) {
+                if (response.data && response.data.messages) {
+                    // receive server messages
+                    _.forEach(response.data.messages, function (msg) {
+                        if (msg.channel) {
+                            proxy.trigger('message', msg.channel, msg.message);
+                        } else {
+                            proxy.trigger('message', 'malformed', msg);
+                        }
+                    });
+                }
+                next();
+            });
 
         delegateProxy = delegator(proxy, proxyAdapter, {
             name: 'proxy',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3942

Update the proxy component in order to be able to take care of messages that come outside of the communicator channel. Those messages are sent by the server aside the responses of regular actions.

This is to prepare the fusion of all communication channels into one.
