### PR TITLE
Feature/tao 4360 add itemdata to loaditem event

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.1.0',
+    'version' => '6.2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.1.0');
+        $this->skip('6.0.1', '6.2.0');
 	}
 }

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -227,7 +227,7 @@ define([
 
                 providerRun('loadItem', itemRef).then(function(itemData){
                     self.setItemState(itemRef, 'loaded', true)
-                        .trigger('loaditem', itemRef)
+                        .trigger('loaditem', itemRef, itemData)
                         .renderItem(itemRef, itemData);
                 }).catch(reportError);
                 return this;

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -375,12 +375,12 @@ define([
     });
 
     QUnit.asyncTest('item state', function(assert){
-       QUnit.expect(15);
-
         var items = {
             'aaa' : 'AAA',
             'zzz' : 'ZZZ'
         };
+
+        QUnit.expect(17);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker : function(){
@@ -388,12 +388,11 @@ define([
             },
             init : _.noop,
             loadItem : function(itemRef){
-               return items[itemRef];
+                return items[itemRef];
             }
         });
 
-        var runner = runnerFactory('foo');
-        runner
+        runnerFactory('foo')
             .on('init', function(){
 
                 assert.throws(function(){
@@ -419,8 +418,10 @@ define([
             .on('ready', function(){
                 this.loadItem('zzz');
             })
-            .on('loaditem', function(itemRef){
+            .on('loaditem', function(itemRef, itemData){
+
                 assert.equal(itemRef, 'zzz', 'The loaded item is correct');
+                assert.equal(itemData, 'ZZZ', 'The loaded item data is correct');
                 assert.equal(this.getItemState('zzz', 'loaded'), true, 'The item is loaded');
                 assert.equal(this.getItemState('zzz', 'ready'), false, 'The item is not ready');
 
@@ -430,11 +431,12 @@ define([
             .on('renderitem', function(itemRef, itemData){
 
                 assert.equal(itemRef, 'zzz', 'The rendered item is correct');
+                assert.equal(itemData, 'ZZZ', 'The rendered item data is correct');
                 assert.equal(this.getItemState('zzz', 'loaded'), true, 'The item is loaded');
                 assert.equal(this.getItemState('zzz', 'ready'), true, 'The item is ready');
                 assert.equal(this.getItemState('zzz', 'foo'), true, 'The item is foo');
 
-               QUnit.start();
+                QUnit.start();
             })
             .init();
     });


### PR DESCRIPTION
Add `itemData` to the TestRunner's `loaditem` event. 
This event is trigerred when the item is loaded so it sounds natural to be able to access the loaded item data at this stage.