### PR TITLE
Fix/tao 4465 get item params

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.2.0',
+    'version' => '6.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.2.0');
+        $this->skip('6.0.1', '6.2.1');
 	}
 }

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -417,17 +417,18 @@ define([
             /**
              * Gets an item definition by its URI, also gets its current state
              * @param {String} uri - The URI of the item to get
+             * @param {Object} [params] - addtional params to be appended
              * @returns {Promise} - Returns a promise. The item data will be provided on resolve.
              *                      Any error will be provided if rejected.
              * @fires getItem
              */
-            getItem: function getItem(uri) {
+            getItem: function getItem(uri, params) {
                 /**
                  * @event proxy#getItem
                  * @param {Promise} promise
                  * @param {String} uri
                  */
-                return delegate('getItem', uri);
+                return delegate('getItem', uri, params);
             },
 
             /**

--- a/views/js/test/runner/proxy/test.js
+++ b/views/js/test/runner/proxy/test.js
@@ -370,28 +370,35 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
 
 
     QUnit.asyncTest('proxyFactory.getItem', function(assert) {
-        var expectedUri = 'http://tao.dev#item123';
+        var proxy;
+        var expectedUri    = 'http://tao.dev#item123';
+        var expectedParams = {
+            itemIdentifier : 'Item-123'
+        };
 
-        QUnit.expect(7);
+        QUnit.expect(8);
         QUnit.stop();
 
         proxyFactory.registerProvider('default', _.defaults({
-            getItem : function(uri) {
+            getItem : function(uri, params) {
                 assert.ok(true, 'The proxyFactory has delegated the call to getItem');
                 assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI to the getItem method');
+                assert.deepEqual(params, expectedParams, 'The given parameters are corrects');
+
                 QUnit.start();
                 return Promise.resolve();
             }
         }, defaultProxy));
 
-        var proxy = proxyFactory('default').on('getItem', function(promise, uri) {
+        proxy = proxyFactory('default').on('getItem', function(promise, uri) {
             assert.ok(true, 'The proxyFactory has fired the "getItem" event');
             assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "getItem" event');
             assert.equal(uri, expectedUri, 'The proxyFactory has provided the URI through the "getItem" event');
+
             QUnit.start();
         });
 
-        proxy.getItem(expectedUri)
+        proxy.getItem(expectedUri, expectedParams)
             .then(function() {
                 assert.ok(false, 'The proxy must be initialized');
             })
@@ -400,7 +407,7 @@ define(['lodash', 'core/promise', 'core/eventifier', 'taoTests/runner/proxy'], f
             });
 
         proxy.init().then(function () {
-            var result = proxy.getItem(expectedUri);
+            var result = proxy.getItem(expectedUri, expectedParams);
 
             assert.ok(result instanceof Promise, 'The proxyFactory.getItem method has returned a promise');
         });


### PR DESCRIPTION
Enable to add extra parameters to `runner/proxy.getItem` 
In terms of implementation, the need  is to send the `itemIdentifier` in addition to the `itemDefinition`.
The issue is to prevent reading the whole test definition to get the `itemIdentifier`. Unfortunately the `itemIdentifier` is used to retrieve the item state in the state storage. 
Changing this is would result in non backward compatible implementation (unable to retrieve previous states).