### PR TITLE
Fix/timepoint compare

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.3.0',
+    'version' => '6.3.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/models/classes/runner/time/TimePoint.php
+++ b/models/classes/runner/time/TimePoint.php
@@ -228,7 +228,7 @@ class TimePoint implements ArraySerializable, \Serializable, \JsonSerializable
      */
     public function getNormalizedTimestamp()
     {
-        return floor($this->getTimestamp() * self::PRECISION);
+        return round($this->getTimestamp() * self::PRECISION);
     }
 
     /**
@@ -360,7 +360,7 @@ class TimePoint implements ArraySerializable, \Serializable, \JsonSerializable
      * @param array $tags
      * @param int $target
      * @param int $type
-     * @return array
+     * @return bool
      */
     public function match(array $tags = null, $target = self::TARGET_ALL, $type = self::TYPE_ALL)
     {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.3.0');
+        $this->skip('6.0.1', '6.3.1');
 	}
 }


### PR DESCRIPTION
Fix a timeline issue occurring under particular circumstances: when the timestamps are very close (i.e. the same second and a very small delay in microseconds), both could be aligned despite the differences in microseconds.

This issue occurs especially when the `TimePoint` are created within the same action, with a few microseconds delay.