### PR TITLE
Feature/tao 4567 client state cache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,12 +34,12 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.3.1',
+    'version' => '6.4.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',
         'taoBackOffice' => '>=0.8',
-        'tao' => '>=10.1.0'
+        'tao' => '>=10.28.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.3.1');
+        $this->skip('6.0.1', '6.4.0');
 	}
 }

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -585,7 +585,7 @@ define([
             })
             //detect failing request and change the online status
             .use(function(request, response, next){
-                if(response.status === 'error' && self.isConnectivityError(response.data)){
+                if(proxy.isConnectivityError(response.data)){
                     proxy.setOffline('request');
                 } else if (response.data && response.data.sent === true){
                     proxy.setOnline();

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -124,7 +124,7 @@ define([
          */
         function delegate(fnName) {
             var request = {command: fnName, params: _slice.call(arguments, 1)};
-            if (!initialized && fnName !== 'init') {
+            if (!initialized && !_.contains(['install', 'init'], fnName)) {
                 return Promise.reject(new Error('Proxy is not properly initialized or has been destroyed!'));
             }
             return delegateProxy.apply(null, arguments)
@@ -170,6 +170,15 @@ define([
                     }
                 });
                 return this;
+            },
+
+            /**
+             * Install the proxy. Optionnal.
+             * This step let's attach some features before the proxy reallys starts (before init).
+             * @returns {*}
+             */
+            install: function install() {
+                return delegate('install');
             },
 
             /**

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -430,6 +430,8 @@ define([
                     proxy.on('error', function (error) {
                         self.trigger('error', error);
                     });
+
+                    proxy.install();
                 }
                 return proxy;
             },

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -771,10 +771,10 @@ define([
     });
 
     QUnit.asyncTest('proxy', function(assert) {
-        QUnit.expect(6);
 
         var expectedProxy = eventifier({
-            init: function(){},
+            init: _.noop,
+            install : _.noop,
             destroy: function() {
                 assert.ok(true, 'The proxy.destroy method has been called');
                 return Promise.resolve();
@@ -782,6 +782,8 @@ define([
         });
 
         var expectedError = "an error";
+
+        QUnit.expect(6);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker : function(){
@@ -805,12 +807,12 @@ define([
                         assert.ok(true, 'The runner is destroying');
                         QUnit.start();
                     })
-                    .getProxy().trigger('error', expectedError);
+                    .getProxy()
+                    .trigger('error', expectedError);
             }
         });
 
-        runnerFactory('foo')
-            .init();
+        runnerFactory('foo').init();
     });
 
     QUnit.test('probeOverseer', function(assert) {


### PR DESCRIPTION
 - Add the `install` step to the proxy. This is an optional step the providers can use to install some behavior. 
 - Make the proxy connectivity aware, it depends on the global connectivity but can be forced online/offline by external factors or by the providers themselves
 - Add a middleware that detects connectivty errors based on an response pattern (`code = 0 && sent = false`).