### PR TITLE
Fix/tao 5126 loaditem in the event stack

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.4.0',
+    'version' => '6.4.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.4.0');
+        $this->skip('6.0.1', '6.4.1');
 	}
 }

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -184,7 +184,8 @@ define([
                     .then(_.partial(pluginRun, 'init'))
                     .then(function() {
                         self.setState('init', true)
-                            .after('init', function initDone(){
+                            .off('init.internal')
+                            .after('init.internal', function initDone(){
                                 this.render();
                             })
                             .trigger('init');
@@ -229,7 +230,8 @@ define([
 
                 providerRun('loadItem', itemRef).then(function(itemData){
                     self.setItemState(itemRef, 'loaded', true)
-                        .after('loaditem', function loadItemDone(){
+                        .off('loaditem.internal')
+                        .after('loaditem.internal', function loadItemDone(){
                             this.renderItem(itemRef, itemData);
                         })
                         .trigger('loaditem', itemRef, itemData);

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -117,7 +117,7 @@ define([
             var args = [].slice.call(arguments, 1);
             return new Promise(function(resolve){
                 if(!_.isFunction(provider[method])){
-                   return resolve();
+                    return resolve();
                 }
                 return resolve(provider[method].apply(runner, args));
             });
@@ -184,8 +184,10 @@ define([
                     .then(_.partial(pluginRun, 'init'))
                     .then(function() {
                         self.setState('init', true)
-                            .trigger('init')
-                            .render();
+                            .after('init', function initDone(){
+                                this.render();
+                            })
+                            .trigger('init');
                     })
                     .catch(reportError);
 
@@ -227,8 +229,10 @@ define([
 
                 providerRun('loadItem', itemRef).then(function(itemData){
                     self.setItemState(itemRef, 'loaded', true)
-                        .trigger('loaditem', itemRef, itemData)
-                        .renderItem(itemRef, itemData);
+                        .after('loaditem', function loadItemDone(){
+                            this.renderItem(itemRef, itemData);
+                        })
+                        .trigger('loaditem', itemRef, itemData);
                 }).catch(reportError);
                 return this;
             },
@@ -484,11 +488,10 @@ define([
              * @returns {Boolean} if active, false if not set
              */
             getPersistentState : function getPersistentState(name) {
-                var getPersistentState = provider.getPersistentState;
                 var state;
 
-                if(_.isFunction(getPersistentState)){
-                    state = getPersistentState.call(runner, name);
+                if(_.isFunction(provider.getPersistentState)){
+                    state = provider.getPersistentState.call(runner, name);
                 }
 
                 return !!state;
@@ -727,6 +730,6 @@ define([
         if(!_.isFunction(provider.loadAreaBroker)){
             throw new TypeError('The runner provider MUST have a method that returns an areaBroker');
         }
-       return true;
+        return true;
     });
 });


### PR DESCRIPTION
It's change I'd like to do from a long time, so this bug was the opportunity. In `taoTests/runner/runner`, `render` and `renderItem` are triggered after respectively `init` and `loadItem`. They were correctly called after all the providers and plugin chain but it wasn't possible to interrupt them.  
Using the artificial `off/on` with a namespace, we can now interrupt the stack. This is useful in case of error or if you want to interrupt them intentionally. 

I've also fixed a bit the underlying unit test (eslint error and redundancies) 