### PR TITLE
Feature/tao 5206 runner data holder

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.4.1',
+    'version' => '6.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.4.1');
+        $this->skip('6.0.1', '6.5.0');
 	}
 }

--- a/views/js/runner/dataHolder.js
+++ b/views/js/runner/dataHolder.js
@@ -1,0 +1,53 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technlogies SA
+ *
+ */
+
+/**
+ * Holds the test runner data.
+ *
+ * @example
+ * var holder = holder();
+ * holder.get('testMap');
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'core/collections'
+], function (collections) {
+    'use strict';
+
+    /**
+     * @type {String[]} the list of default objects to create
+     */
+    var defaultObjects = ['testData', 'testContext', 'testMap'];
+
+    /**
+     * Creates a new data holder,
+     * with default entries.
+     *
+     * @returns {Map} the holder
+     */
+    return function dataHolderFactory(){
+        var map = new collections.Map();
+        defaultObjects.forEach(function(entry){
+            map.set(entry, {});
+        });
+
+        return map;
+    };
+});

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -43,6 +43,8 @@ define([
      * @returns {proxy} - The proxy instance, bound to the selected proxy adapter
      */
     function proxyFactory(proxyName, config) {
+        var proxy, delegateProxy, communicator, communicatorPromise;
+        var holder;
 
         var extraCallParams = {};
         var proxyAdapter    = proxyFactory.getProvider(proxyName);
@@ -51,7 +53,7 @@ define([
         var middlewares     = {};
         var initialized     = false;
         var onlineStatus    = connectivity.isOnline();
-        var proxy, delegateProxy, communicator, communicatorPromise;
+
 
         /**
          * Gets parameters merged with extra parameters
@@ -173,11 +175,16 @@ define([
             },
 
             /**
-             * Install the proxy. Optionnal.
+             * Install the proxy.
              * This step let's attach some features before the proxy reallys starts (before init).
+             *
+             * @param {Map} holder - the test runner data holder
              * @returns {*}
              */
-            install: function install() {
+            install: function install(dataHolder) {
+                if(dataHolder){
+                    holder = dataHolder;
+                }
                 return delegate('install');
             },
 
@@ -239,6 +246,14 @@ define([
                         });
                     }
                 });
+            },
+
+            /**
+             * Get the map that holds the test data
+             * @returns {Map|Object} the dataHolder
+             */
+            getDataHolder : function getDataHolder(){
+                return holder;
             },
 
             /**

--- a/views/js/runner/proxy.js
+++ b/views/js/runner/proxy.js
@@ -44,7 +44,7 @@ define([
      */
     function proxyFactory(proxyName, config) {
         var proxy, delegateProxy, communicator, communicatorPromise;
-        var holder;
+        var testDataHolder;
 
         var extraCallParams = {};
         var proxyAdapter    = proxyFactory.getProvider(proxyName);
@@ -178,12 +178,12 @@ define([
              * Install the proxy.
              * This step let's attach some features before the proxy reallys starts (before init).
              *
-             * @param {Map} holder - the test runner data holder
+             * @param {Map} dataHolder - the test runner data holder
              * @returns {*}
              */
             install: function install(dataHolder) {
                 if(dataHolder){
-                    holder = dataHolder;
+                    testDataHolder = dataHolder;
                 }
                 return delegate('install');
             },
@@ -253,7 +253,7 @@ define([
              * @returns {Map|Object} the dataHolder
              */
             getDataHolder : function getDataHolder(){
-                return holder;
+                return testDataHolder;
             },
 
             /**

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -26,8 +26,9 @@ define([
     'core/eventifier',
     'core/promise',
     'core/logger',
-    'core/providerRegistry'
-], function ($, _, __, eventifier, Promise, logger, providerRegistry){
+    'core/providerRegistry',
+    'taoTests/runner/dataHolder'
+], function ($, _, __, eventifier, Promise, logger, providerRegistry, dataHolder){
     'use strict';
 
     /**
@@ -47,24 +48,14 @@ define([
         var runner;
 
         /**
-         * @type {Object} the test definition data
+         * @type {Map} Contains the test runner data
          */
-        var testData       = {};
-
-        /**
-         * @type {Object} contextual test data (the state of the test)
-         */
-        var testContext    = {};
-
-        /**
-         * @type {Object} contextual test map (the map of accessible items)
-         */
-        var testMap        = {};
+        var holder = dataHolder();
 
         /**
          * @type {Object} the registered plugins
          */
-        var plugins        = {};
+        var plugins = {};
 
         /**
          * @type {Object} the test of the runner
@@ -178,7 +169,8 @@ define([
                     plugins[plugin.getName()] = plugin;
                 });
 
-                providerRun('loadPersistentStates')
+                providerRun('install')
+                    .then(_.partial(providerRun, 'loadPersistentStates'))
                     .then(_.partial(pluginRun, 'install'))
                     .then(_.partial(providerRun, 'init'))
                     .then(_.partial(pluginRun, 'init'))
@@ -373,8 +365,9 @@ define([
                         }
 
                         return destroyed.then(function() {
-                            testContext = {};
-                            self.setState('destroy', true)
+                            self.setTestContext({})
+                                .setTestMap({})
+                                .setState('destroy', true)
                                 .trigger('destroy');
                         });
                     }).catch(reportError);
@@ -437,7 +430,7 @@ define([
                         self.trigger('error', error);
                     });
 
-                    proxy.install();
+                    proxy.install(holder);
                 }
                 return proxy;
             },
@@ -569,17 +562,18 @@ define([
              * @returns {Object} the test data
              */
             getTestData : function getTestData(){
-                return testData;
+                return holder && holder.get('testData');
             },
 
             /**
              * Set the test data/definition
-             * @param {Object} data - the test data
+             * @param {Object} testData - the test data
              * @returns {runner} chains
              */
-            setTestData : function setTestData(data){
-                testData  = data;
-
+            setTestData : function setTestData(testData){
+                if(holder && _.isPlainObject(testData)){
+                    holder.set('testData', testData);
+                }
                 return this;
             },
 
@@ -588,17 +582,17 @@ define([
              * @returns {Object} the test context
              */
             getTestContext : function getTestContext(){
-                return testContext;
+                return holder && holder.get('testContext');
             },
 
             /**
              * Set the test context/state
-             * @param {Object} context - the context to set
+             * @param {Object} testContext - the context to set
              * @returns {runner} chains
              */
-            setTestContext : function setTestContext(context){
-                if(_.isPlainObject(context)){
-                    testContext = context;
+            setTestContext : function setTestContext(testContext){
+                if(holder && _.isPlainObject(testContext)){
+                    holder.set('testContext', testContext);
                 }
                 return this;
             },
@@ -608,17 +602,17 @@ define([
              * @returns {Object} the test map
              */
             getTestMap : function getTestMap(){
-                return testMap;
+                return holder && holder.get('testMap');
             },
 
             /**
              * Set the test items map
-             * @param {Object} map - the map to set
+             * @param {Object} testMap - the map to set
              * @returns {runner} chains
              */
-            setTestMap : function setTestMap(map){
-                if(_.isPlainObject(map)){
-                    testMap = map;
+            setTestMap : function setTestMap(testMap){
+                if(holder && _.isPlainObject(testMap)){
+                    holder.set('testMap', testMap);
                 }
                 return this;
             },

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -28,7 +28,7 @@ define([
     'core/logger',
     'core/providerRegistry',
     'taoTests/runner/dataHolder'
-], function ($, _, __, eventifier, Promise, logger, providerRegistry, dataHolder){
+], function ($, _, __, eventifier, Promise, logger, providerRegistry, dataHolderFactory){
     'use strict';
 
     /**
@@ -50,7 +50,7 @@ define([
         /**
          * @type {Map} Contains the test runner data
          */
-        var holder = dataHolder();
+        var dataHolder = dataHolderFactory();
 
         /**
          * @type {Object} the registered plugins
@@ -430,7 +430,7 @@ define([
                         self.trigger('error', error);
                     });
 
-                    proxy.install(holder);
+                    proxy.install(dataHolder);
                 }
                 return proxy;
             },
@@ -562,7 +562,7 @@ define([
              * @returns {Object} the test data
              */
             getTestData : function getTestData(){
-                return holder && holder.get('testData');
+                return dataHolder && dataHolder.get('testData');
             },
 
             /**
@@ -571,8 +571,8 @@ define([
              * @returns {runner} chains
              */
             setTestData : function setTestData(testData){
-                if(holder && _.isPlainObject(testData)){
-                    holder.set('testData', testData);
+                if(dataHolder && _.isPlainObject(testData)){
+                    dataHolder.set('testData', testData);
                 }
                 return this;
             },
@@ -582,7 +582,7 @@ define([
              * @returns {Object} the test context
              */
             getTestContext : function getTestContext(){
-                return holder && holder.get('testContext');
+                return dataHolder && dataHolder.get('testContext');
             },
 
             /**
@@ -591,8 +591,8 @@ define([
              * @returns {runner} chains
              */
             setTestContext : function setTestContext(testContext){
-                if(holder && _.isPlainObject(testContext)){
-                    holder.set('testContext', testContext);
+                if(dataHolder && _.isPlainObject(testContext)){
+                    dataHolder.set('testContext', testContext);
                 }
                 return this;
             },
@@ -602,7 +602,7 @@ define([
              * @returns {Object} the test map
              */
             getTestMap : function getTestMap(){
-                return holder && holder.get('testMap');
+                return dataHolder && dataHolder.get('testMap');
             },
 
             /**
@@ -611,8 +611,8 @@ define([
              * @returns {runner} chains
              */
             setTestMap : function setTestMap(testMap){
-                if(holder && _.isPlainObject(testMap)){
-                    holder.set('testMap', testMap);
+                if(dataHolder && _.isPlainObject(testMap)){
+                    dataHolder.set('testMap', testMap);
                 }
                 return this;
             },

--- a/views/js/test/runner/dataHolder/test.html
+++ b/views/js/test/runner/dataHolder/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner - Data Holder</title>
+        <base href="../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="runner/dataHolder.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoTests/test/runner/dataHolder/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/dataHolder/test.js
+++ b/views/js/test/runner/dataHolder/test.js
@@ -1,0 +1,59 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Test the dataHolder
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'core/collections',
+    'taoTests/runner/dataHolder',
+], function (collections, dataHolderFactory){
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', function (assert){
+        QUnit.expect(1);
+
+        assert.equal(typeof dataHolderFactory, 'function', "The module exposes a function");
+    });
+
+    QUnit.test('factory', function (assert){
+        var holder;
+        QUnit.expect(2);
+
+        holder =  dataHolderFactory();
+
+        assert.equal(typeof holder, 'object', 'The factory creates an object');
+        assert.ok(holder instanceof collections.Map, 'The holder is a common Map');
+    });
+
+    QUnit.test('defaults', function (assert){
+        var holder;
+        QUnit.expect(4);
+
+        holder =  dataHolderFactory();
+
+        assert.equal(typeof holder.get('testFoo'), 'undefined', 'testFoo is not a default');
+        assert.equal(typeof holder.get('testData'), 'object', 'testData is a default');
+        assert.equal(typeof holder.get('testContext'), 'object', 'testContext is a default');
+        assert.equal(typeof holder.get('testMap'), 'object', 'testMap is a default');
+    });
+});

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -31,7 +31,8 @@ define([
 
     var mockProvider = {
         init : _.noop,
-        loadAreaBroker  : _.noop
+        loadAreaBroker  : _.noop,
+        loadProxy : _.noop
     };
 
     var items = {
@@ -75,9 +76,8 @@ define([
         {name : 'getItemState', title : 'getItemState'},
         {name : 'setItemState', title : 'setItemState'},
         {name : 'getTestData', title : 'getTestData'},
-        {name : 'setTestData', title : 'setTestData'},
         {name : 'getTestContext', title : 'getTestContext'},
-        {name : 'setTestContext', title : 'setTestContext'},
+        {name : 'getTestMap', title : 'getTestMap'},
         {name : 'getAreaBroker', title : 'getAreaBroker'},
         {name : 'getProxy', title : 'getProxy'},
         {name : 'getProbeOverseer', title : 'getProbeOverseer'},
@@ -519,7 +519,7 @@ define([
             map: {}
         };
 
-        QUnit.expect(10);
+        QUnit.expect(12);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker : _.noop,
@@ -532,6 +532,10 @@ define([
         });
 
         runnerFactory('foo')
+            .on('error', function(err){
+                assert.ok(false, err);
+                QUnit.start();
+            })
             .on('init', function(){
 
                 var context = this.getTestContext();
@@ -550,11 +554,14 @@ define([
             .on('destroy', function(){
                 var context = this.getTestContext();
                 var data    = this.getTestData();
+                var map     = this.getTestMap();
 
                 assert.equal(typeof context, 'object', 'The test context is an object');
                 assert.equal(typeof data, 'object', 'The test data is an object');
+                assert.equal(typeof map, 'object', 'The test map is an object');
                 assert.deepEqual(data, testData, 'The test data is correct');
                 assert.equal(typeof context.best, 'undefined', 'The context is now empty');
+                assert.equal(typeof map.jumps, 'undefined', 'The map is now empty');
 
                 QUnit.start();
             })


### PR DESCRIPTION
 - Move `testData`, `testContext` and `testMap` to a separate module `dataHolder`, in order to let composed elements (ie. proxy providers) access test runner's data without creating cyclic dependencies.
- Add an `install` step in the test runner lifecycle (before init, it let's you install some behavior)