### PR TITLE
Feature/tao 5355 get data holder

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.6.0',
+    'version' => '6.7.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -88,6 +88,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
 
-        $this->skip('6.0.1', '6.6.0');
-	}
+        $this->skip('6.0.1', '6.7.0');
+    }
 }

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -618,6 +618,14 @@ define([
             },
 
             /**
+             * Get the data holder
+             * @returns {dataHolder}
+             */
+            getDataHolder : function getDataHolder(){
+                return dataHolder;
+            },
+
+            /**
              * Move next alias
              * @param {String|*} [scope] - the movement scope
              * @fires runner#move

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -81,6 +81,7 @@ define([
         {name : 'getAreaBroker', title : 'getAreaBroker'},
         {name : 'getProxy', title : 'getProxy'},
         {name : 'getProbeOverseer', title : 'getProbeOverseer'},
+        {name : 'getDataHolder', title : 'getDataHolder'},
 
         {name : 'next', title : 'next'},
         {name : 'previous', title : 'previous'},
@@ -828,6 +829,23 @@ define([
                 init :  _.noop
             });
         }, 'An exception is thrown when the loadAreaBroker() is missing');
+    });
+
+    QUnit.test('getDataHolder', function(assert) {
+        var dataHolder;
+
+        QUnit.expect(6);
+
+        runnerFactory.registerProvider('foo', mockProvider);
+
+        dataHolder = runnerFactory('foo').getDataHolder();
+
+        assert.equal(typeof dataHolder, 'object', 'The runner exposes the data holder');
+        assert.equal(typeof dataHolder.get, 'function', 'The data holder has the get method');
+        assert.equal(typeof dataHolder.set, 'function', 'The data holder has the set method');
+        assert.equal(typeof dataHolder.get('testData'), 'object', 'The data holder holds the correct data');
+        assert.equal(typeof dataHolder.get('testContext'), 'object', 'The data holder holds the correct data');
+        assert.equal(typeof dataHolder.get('testMap'), 'object', 'The data holder holds the correct data');
     });
 
 


### PR DESCRIPTION
Make the test runner exposes the data holder through  the `getDataHolder` method.