### PR TITLE
Feature/tao 5701 provider registry

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,12 +34,12 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.8.0',
+    'version' => '6.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',
         'taoBackOffice' => '>=0.8',
-        'tao' => '>=10.28.0'
+        'tao' => '>=14.12.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOTest.rdf',
@@ -50,6 +50,7 @@ return array(
 		),
             'php' => [
                 'oat\\taoTests\\scripts\\install\\RegisterTestPluginService',
+                'oat\\taoTests\\scripts\\install\\RegisterTestProviderService',
                 'oat\\taoTests\\scripts\\install\\RegisterTestRunnerFeatureService',
             ]
 	),

--- a/models/classes/runner/providers/ProviderRegistry.php
+++ b/models/classes/runner/providers/ProviderRegistry.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTests\models\runner\providers;
+
+use common_ext_ExtensionsManager;
+use oat\tao\model\providers\AbstractProviderRegistry;
+
+/**
+ * Store the <b>available</b> test runner providers, even if not activated,
+ * providers have to be registered.
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class ProviderRegistry extends AbstractProviderRegistry
+{
+    /**
+     * @see \oat\oatbox\AbstractRegistry::getConfigId()
+     */
+    protected function getConfigId()
+    {
+        return 'test_runner_provider_registry';
+    }
+
+    /**
+     * @see \oat\oatbox\AbstractRegistry::getExtension()
+     */
+    protected function getExtension()
+    {
+        return common_ext_ExtensionsManager::singleton()->getExtensionById('taoTests');
+    }
+}

--- a/models/classes/runner/providers/ProviderRegistry.php
+++ b/models/classes/runner/providers/ProviderRegistry.php
@@ -20,7 +20,7 @@
 namespace oat\taoTests\models\runner\providers;
 
 use common_ext_ExtensionsManager;
-use oat\tao\model\providers\AbstractProviderRegistry;
+use oat\tao\model\modules\AbstractModuleRegistry;
 
 /**
  * Store the <b>available</b> test runner providers, even if not activated,
@@ -29,7 +29,7 @@ use oat\tao\model\providers\AbstractProviderRegistry;
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-class ProviderRegistry extends AbstractProviderRegistry
+class ProviderRegistry extends AbstractModuleRegistry
 {
     /**
      * @see \oat\oatbox\AbstractRegistry::getConfigId()

--- a/models/classes/runner/providers/TestProvider.php
+++ b/models/classes/runner/providers/TestProvider.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTests\models\runner\providers;
+
+use oat\tao\model\providers\ProviderModule;
+
+/**
+ * A pojo that represents a test runner provider.
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class TestProvider extends ProviderModule
+{
+    // simple override, just to keep compatibility
+}

--- a/models/classes/runner/providers/TestProviderService.php
+++ b/models/classes/runner/providers/TestProviderService.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTests\models\runner\providers;
+
+use oat\tao\model\providers\AbstractProviderService;
+use oat\tao\model\providers\ProviderModule;
+
+/**
+ * Manage test providers
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class TestProviderService extends AbstractProviderService
+{
+    const SERVICE_ID = 'taoTests/TestProvider';
+
+    /**
+     * TestProviderService constructor.
+     * @param array $options
+     */
+    public function __construct($options = array())
+    {
+        parent::__construct($options);
+        $this->setRegistry(ProviderRegistry::getRegistry());
+    }
+
+    /**
+     * Creates a provider object from data array
+     * @param $data
+     * @return ProviderModule
+     * @throws \common_exception_InconsistentData
+     */
+    protected function createFromArray($data)
+    {
+        return TestProvider::fromArray($data);
+    }
+}

--- a/scripts/install/RegisterTestPluginService.php
+++ b/scripts/install/RegisterTestPluginService.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoTests\scripts\install;
 
+use oat\oatbox\extension\InstallAction;
 use oat\taoTests\models\runner\plugins\TestPluginService;
 
 /**
@@ -28,7 +29,7 @@ use oat\taoTests\models\runner\plugins\TestPluginService;
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-class RegisterTestPluginService extends \common_ext_action_InstallAction
+class RegisterTestPluginService extends InstallAction
 {
     /**
      * @param $params

--- a/scripts/install/RegisterTestPluginService.php
+++ b/scripts/install/RegisterTestPluginService.php
@@ -40,7 +40,6 @@ class RegisterTestPluginService extends InstallAction
     {
         $serviceManager = $this->getServiceManager();
         $testPluginService = new TestPluginService();
-        $serviceManager->propagate($testPluginService);
         $serviceManager->register(TestPluginService::SERVICE_ID, $testPluginService);
     }
 }

--- a/scripts/install/RegisterTestPluginService.php
+++ b/scripts/install/RegisterTestPluginService.php
@@ -22,7 +22,6 @@
 namespace oat\taoTests\scripts\install;
 
 use oat\taoTests\models\runner\plugins\TestPluginService;
-use oat\oatbox\service\ServiceManager;
 
 /**
  * Installation action that registers the TestPluginService
@@ -33,13 +32,14 @@ class RegisterTestPluginService extends \common_ext_action_InstallAction
 {
     /**
      * @param $params
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function __invoke($params)
     {
-        $serviceManager = ServiceManager::getServiceManager();
-
+        $serviceManager = $this->getServiceManager();
         $testPluginService = new TestPluginService();
-        $testPluginService->setServiceManager($serviceManager);
+        $serviceManager->propagate($testPluginService);
         $serviceManager->register(TestPluginService::SERVICE_ID, $testPluginService);
     }
 }

--- a/scripts/install/RegisterTestProviderService.php
+++ b/scripts/install/RegisterTestProviderService.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTests\scripts\install;
+
+use oat\taoTests\models\runner\providers\TestProviderService;
+
+/**
+ * Installation action that registers the TestProviderService
+ *
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class RegisterTestProviderService extends \common_ext_action_InstallAction
+{
+    /**
+     * @param $params
+     * @throws \common_Exception
+     * @throws \common_exception_Error
+     */
+    public function __invoke($params)
+    {
+        $serviceManager = $this->getServiceManager();
+        $testProviderService = new TestProviderService();
+        $serviceManager->propagate($testProviderService);
+        $serviceManager->register(TestProviderService::SERVICE_ID, $testProviderService);
+    }
+}
+

--- a/scripts/install/RegisterTestProviderService.php
+++ b/scripts/install/RegisterTestProviderService.php
@@ -19,6 +19,7 @@
 
 namespace oat\taoTests\scripts\install;
 
+use oat\oatbox\extension\InstallAction;
 use oat\taoTests\models\runner\providers\TestProviderService;
 
 /**
@@ -26,7 +27,7 @@ use oat\taoTests\models\runner\providers\TestProviderService;
  *
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-class RegisterTestProviderService extends \common_ext_action_InstallAction
+class RegisterTestProviderService extends InstallAction
 {
     /**
      * @param $params

--- a/scripts/install/RegisterTestProviderService.php
+++ b/scripts/install/RegisterTestProviderService.php
@@ -38,7 +38,6 @@ class RegisterTestProviderService extends InstallAction
     {
         $serviceManager = $this->getServiceManager();
         $testProviderService = new TestProviderService();
-        $serviceManager->propagate($testProviderService);
         $serviceManager->register(TestProviderService::SERVICE_ID, $testProviderService);
     }
 }

--- a/scripts/install/RegisterTestRunnerFeatureService.php
+++ b/scripts/install/RegisterTestRunnerFeatureService.php
@@ -21,7 +21,6 @@
 
 namespace oat\taoTests\scripts\install;
 
-use oat\oatbox\service\ServiceManager;
 use oat\taoTests\models\runner\features\TestRunnerFeatureService;
 
 /**
@@ -33,13 +32,14 @@ class RegisterTestRunnerFeatureService extends \common_ext_action_InstallAction
 {
     /**
      * @param $params
+     * @throws \common_Exception
+     * @throws \common_exception_Error
      */
     public function __invoke($params)
     {
-        $serviceManager = ServiceManager::getServiceManager();
-
+        $serviceManager = $this->getServiceManager();
         $testRunnerFeatureService = new TestRunnerFeatureService();
-        $testRunnerFeatureService->setServiceManager($serviceManager);
+        $serviceManager->propagate($testRunnerFeatureService);
         $serviceManager->register(TestRunnerFeatureService::SERVICE_ID, $testRunnerFeatureService);
     }
 }

--- a/scripts/install/RegisterTestRunnerFeatureService.php
+++ b/scripts/install/RegisterTestRunnerFeatureService.php
@@ -40,7 +40,6 @@ class RegisterTestRunnerFeatureService extends InstallAction
     {
         $serviceManager = $this->getServiceManager();
         $testRunnerFeatureService = new TestRunnerFeatureService();
-        $serviceManager->propagate($testRunnerFeatureService);
         $serviceManager->register(TestRunnerFeatureService::SERVICE_ID, $testRunnerFeatureService);
     }
 }

--- a/scripts/install/RegisterTestRunnerFeatureService.php
+++ b/scripts/install/RegisterTestRunnerFeatureService.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoTests\scripts\install;
 
+use oat\oatbox\extension\InstallAction;
 use oat\taoTests\models\runner\features\TestRunnerFeatureService;
 
 /**
@@ -28,7 +29,7 @@ use oat\taoTests\models\runner\features\TestRunnerFeatureService;
  *
  * @author Christophe Noël <christophe@taotesting.com>
  */
-class RegisterTestRunnerFeatureService extends \common_ext_action_InstallAction
+class RegisterTestRunnerFeatureService extends InstallAction
 {
     /**
      * @param $params

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -22,6 +22,7 @@
 namespace oat\taoTests\scripts\update;
 
 use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoTests\models\runner\providers\TestProviderService;
 use oat\taoTests\scripts\install\RegisterTestPluginService;
 use oat\taoTests\scripts\install\RegisterTestRunnerFeatureService;
 use oat\tao\model\accessControl\func\AclProxy;
@@ -89,5 +90,16 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('6.0.1', '6.8.0');
+
+        if ($this->isVersion('6.8.0')){
+
+            //register test plugin service
+            $serviceManager = $this->getServiceManager();
+            $testProviderService = new TestProviderService();
+            $serviceManager->propagate($testProviderService);
+            $serviceManager->register(TestProviderService::SERVICE_ID, $testProviderService);
+
+            $this->setVersion('6.9.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -96,7 +96,6 @@ class Updater extends \common_ext_ExtensionUpdater
             //register test plugin service
             $serviceManager = $this->getServiceManager();
             $testProviderService = new TestProviderService();
-            $serviceManager->propagate($testProviderService);
             $serviceManager->register(TestProviderService::SERVICE_ID, $testProviderService);
 
             $this->setVersion('6.9.0');

--- a/test/runner/providers/TestProviderServiceTest.php
+++ b/test/runner/providers/TestProviderServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoTests\test\runner\providers;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\taoTests\models\runner\providers\ProviderRegistry;
+use oat\taoTests\models\runner\providers\TestProvider;
+use oat\taoTests\models\runner\providers\TestProviderService;
+use Prophecy\Prophet;
+
+/**
+ * Test the TestProviderService
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class TestProviderServiceTest extends TaoPhpUnitTestRunner
+{
+
+    //data to stub the regiitry content
+    private static $providerData = [
+        'taoQtiTest/runner/providers/qtiRunner' => [
+            'id' => 'qtiRunner',
+            'module' => 'taoQtiTest/runner/providers/qtiRunner',
+            'bundle' => 'providers/bundle.min',
+            'name' => 'QTI runner',
+            'description' => 'QTI implementation of the test runner',
+            'category' => 'runner',
+            'active' => true,
+            'tags' => ['core', 'qti', 'runner']
+        ],
+        'taoQtiTest/runner/providers/qtiPreviewer' => [
+            'id' => 'qtiPreviewer',
+            'module' => 'taoQtiTest/runner/providers/qtiPreviewer',
+            'bundle' => 'providers/bundle.min',
+            'name' => 'QTI previewer',
+            'description' => 'QTI implementation of the test/item previewer',
+            'category' => 'previewer',
+            'active' => true,
+            'tags' => ['core', 'qti', 'previewer']
+        ]
+    ];
+
+    /**
+     * Get the service with the stubbed registry
+     * @return TestProviderService
+     */
+    protected function getTestProviderService()
+    {
+        $testProviderService = new TestProviderService();
+
+        $prophet = new Prophet();
+        $prophecy = $prophet->prophesize();
+        $prophecy->willExtend(ProviderRegistry::class);
+        $prophecy->getMap()->willReturn(self::$providerData);
+
+        $testProviderService->setRegistry($prophecy->reveal());
+
+        return $testProviderService;
+    }
+
+    /**
+     * Check the service is a service
+     */
+    public function testApi()
+    {
+        $testProviderService = $this->getTestProviderService();
+        $this->assertInstanceOf(TestProviderService::class, $testProviderService);
+        $this->assertInstanceOf(ConfigurableService::class, $testProviderService);
+    }
+
+    /**
+     * Test the method TestProviderService::getAllProviders
+     */
+    public function testGetAllProviders()
+    {
+        $testProviderService = $this->getTestProviderService();
+
+        $providers = $testProviderService->getAllProviders();
+
+        $this->assertEquals(2, count($providers));
+
+        $provider0 = $providers['taoQtiTest/runner/providers/qtiRunner'];
+        $provider1 = $providers['taoQtiTest/runner/providers/qtiPreviewer'];
+
+        $this->assertInstanceOf(TestProvider::class, $provider0);
+        $this->assertInstanceOf(TestProvider::class, $provider1);
+
+        $this->assertEquals('qtiRunner', $provider0->getId());
+        $this->assertEquals('qtiPreviewer', $provider1->getId());
+
+        $this->assertEquals('QTI runner', $provider0->getName());
+        $this->assertEquals('QTI previewer', $provider1->getName());
+
+        $this->assertTrue($provider0->isActive());
+        $this->assertTrue($provider1->isActive());
+    }
+
+    /**
+     * Test the method TestProviderService::getProvider
+     */
+    public function testGetOneProvider()
+    {
+        $testProviderService = $this->getTestProviderService();
+
+        $provider = $testProviderService->getProvider('qtiRunner');
+
+        $this->assertInstanceOf(TestProvider::class, $provider);
+        $this->assertEquals('qtiRunner', $provider->getId());
+        $this->assertEquals('QTI runner', $provider->getName());
+        $this->assertEquals('taoQtiTest/runner/providers/qtiRunner', $provider->getModule());
+        $this->assertEquals('runner', $provider->getCategory());
+
+        $this->assertTrue($provider->isActive());
+    }
+
+}

--- a/test/runner/providers/TestProviderTest.php
+++ b/test/runner/providers/TestProviderTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTests\test\runner\providers;
+
+use common_exception_InconsistentData;
+use oat\taoTests\models\runner\providers\TestProvider;
+use oat\tao\test\TaoPhpUnitTestRunner;
+
+/**
+ * Test the TestProvider pojo
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class TestProviderTest extends TaoPhpUnitTestRunner
+{
+
+    /**
+     * Data provider
+     * @return array the data
+     */
+    public function accessorsProvider()
+    {
+        return [
+            [
+                [
+                    'id' => 'foo',
+                    'name' => 'Foo',
+                    'module' => 'provider/foo',
+                    'category' => 'dummy',
+                    'description' => 'The best foo ever',
+                    'active' => true,
+                    'tags' => ['required']
+                ], [
+                'id' => 'foo',
+                'name' => 'Foo',
+                'module' => 'provider/foo',
+                'category' => 'dummy',
+                'description' => 'The best foo ever',
+                'active' => true,
+                'tags' => ['required']
+            ]
+            ], [
+                [
+                    'id' => '12',
+                    'name' => 21,
+                    'module' => 'provider/foo',
+                    'category' => 'dummy',
+                ], [
+                    'id' => '12',
+                    'name' => '21',
+                    'module' => 'provider/foo',
+                    'category' => 'dummy',
+                    'description' => '',
+                    'active' => true,
+                    'tags' => []
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testConstructBadId()
+    {
+        new TestProvider(12, 'foo', 'bar');
+    }
+
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testConstructEmptyId()
+    {
+        new TestProvider('', 'foo', 'bar');
+    }
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testConstructBadModule()
+    {
+        new TestProvider('foo', true, 'bar');
+    }
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testConstructiEmptyModule()
+    {
+        new TestProvider('foo', '', 'bar');
+    }
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testConstructBadCategory()
+    {
+        new TestProvider('foo', 'bar', []);
+    }
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testConstructNoCategory()
+    {
+        new TestProvider('foo', 'bar', null);
+    }
+
+    /**
+     * @expectedException common_exception_InconsistentData
+     */
+    public function testFromArrayNoRequiredData()
+    {
+        TestProvider::fromArray([]);
+    }
+
+    /**
+     * Test contructor and getter
+     * @dataProvider accessorsProvider
+     */
+    public function testConstruct($input, $output)
+    {
+
+        $testProvider = new TestProvider($input['id'], $input['module'], $input['category'], $input);
+
+        $this->assertEquals($output['id'], $testProvider->getId());
+        $this->assertEquals($output['name'], $testProvider->getName());
+        $this->assertEquals($output['module'], $testProvider->getModule());
+        $this->assertEquals($output['category'], $testProvider->getCategory());
+        $this->assertEquals($output['description'], $testProvider->getDescription());
+        $this->assertEquals($output['active'], $testProvider->isActive());
+        $this->assertEquals($output['tags'], $testProvider->getTags());
+
+        $testProvider->setActive(!$output['active']);
+        $this->assertEquals(!$output['active'], $testProvider->isActive());
+    }
+
+    /**
+     * Test from array and getters
+     * @dataProvider accessorsProvider
+     */
+    public function testFromArray($input, $output)
+    {
+
+        $testProvider = TestProvider::fromArray($input);
+
+        $this->assertEquals($output['id'], $testProvider->getId());
+        $this->assertEquals($output['name'], $testProvider->getName());
+        $this->assertEquals($output['module'], $testProvider->getModule());
+        $this->assertEquals($output['category'], $testProvider->getCategory());
+        $this->assertEquals($output['description'], $testProvider->getDescription());
+        $this->assertEquals($output['active'], $testProvider->isActive());
+        $this->assertEquals($output['tags'], $testProvider->getTags());
+
+        $testProvider->setActive(!$output['active']);
+        $this->assertEquals(!$output['active'], $testProvider->isActive());
+    }
+
+    /**
+     * Test encoding the object to json
+     */
+    public function testJsonSerialize()
+    {
+        $expected = '{"id":"bar","module":"bar\/bar","bundle":"providers\/bundle.min","name":"Bar","description":"The best bar ever","category":"dummy","active":false,"tags":["dummy","goofy"]}';
+
+        $testProvider = new TestProvider('bar', 'bar/bar', 'dummy', [
+            'name' => 'Bar',
+            'description' => 'The best bar ever',
+            'active' => false,
+            'bundle' => 'providers/bundle.min',
+            'tags' => ['dummy', 'goofy']
+        ]);
+
+        $serialized = json_encode($testProvider);
+
+        $this->assertEquals($expected, $serialized);
+    }
+}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5701

Requires:
- [x] https://github.com/oat-sa/tao-core/pull/1582

Add a test runner providers registry. It will behalf slightly like the plugins registry, and will be used aside the providers loader.

There is no integration for now, so please check by using the unit test:
`vendor/phpunit/phpunit/phpunit taoTests`
