### PR TITLE
Feature/tao 5148 test runner storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,12 +34,12 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '6.13.0',
+    'version' => '6.14.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoItems' => '>=2.20.1',
         'taoBackOffice' => '>=1.3.0',
-        'tao' => '>=15.0.0'
+        'tao' => '>=15.7.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return array(
     'requires' => array(
         'taoItems' => '>=2.20.1',
         'taoBackOffice' => '>=1.3.0',
-        'tao' => '>=15.11.0'
+        'tao' => '>=16.1.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -101,6 +101,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.11.0');
         }
 
-        $this->skip('6.11.0', '6.13.0');
+        $this->skip('6.11.0', '6.14.0');
     }
 }

--- a/views/js/runner/probeOverseer.js
+++ b/views/js/runner/probeOverseer.js
@@ -76,7 +76,7 @@ define([
             if(queueStorage){
                 return Promise.resolve(queueStorage);
             }
-            return runner.getTestStore().getStore('test-probes').then(function(newStorage){
+            return runner.getTestStore().getStore('test-probe').then(function(newStorage){
                 queueStorage = newStorage;
                 return Promise.resolve(queueStorage);
             });

--- a/views/js/runner/probeOverseer.js
+++ b/views/js/runner/probeOverseer.js
@@ -343,7 +343,7 @@ define([
                 queue = [];
                 immutableQueue = [];
                 return getStorage().then(function(storage){
-                    return storage.removeStore().then(resetStorage);
+                    return storage.removeItem('queue').then(resetStorage);
                 });
             }
         };

--- a/views/js/runner/probeOverseer.js
+++ b/views/js/runner/probeOverseer.js
@@ -25,11 +25,10 @@
 define([
     'lodash',
     'core/promise',
-    'core/store',
     'moment',
     'lib/uuid',
     'lib/moment-timezone.min'
-], function (_, Promise, store, moment, uuid){
+], function (_, Promise, moment, uuid){
     'use strict';
 
     var timeZone = moment.tz.guess();
@@ -38,12 +37,11 @@ define([
 
     /**
      * Create the overseer intance
-     * @param {String} testIdentifier - a unique id for a test execution
      * @param {runner} runner - a instance of a test runner
      * @returns {probeOverseer} the new probe overseer
      * @throws TypeError if something goes wrong
      */
-    return function probeOverseerFactory(testIdentifier, runner){
+    return function probeOverseerFactory(runner){
 
         // the created instance
         var overseer;
@@ -71,10 +69,31 @@ define([
         var started = false;
 
         /**
+         * Get the storage instance
+         * @returns {Promise} that resolves with the storage
+         */
+        var getStorage = function getStorage(){
+            if(queueStorage){
+                return Promise.resolve(queueStorage);
+            }
+            return runner.getTestStore().getStore('test-probes').then(function(newStorage){
+                queueStorage = newStorage;
+                return Promise.resolve(queueStorage);
+            });
+        };
+
+        /**
+         * Unset the storage instance
+         */
+        var resetStorage = function resetStorage() {
+            queueStorage = null;
+        };
+
+        /**
          * Register the collection event of a probe against a runner
          * @param {Object} probe - a valid probe
          */
-        var collectEvent = function collectEvent(probe){
+        function collectEvent(probe){
 
             var eventNs = '.probe-' + probe.name;
 
@@ -102,9 +121,9 @@ define([
                 var listen = eventName.indexOf('.') > 0 ? eventName : eventName + eventNs;
                 runner.on(listen, _.partial(probeHandler, eventName));
             });
-        };
+        }
 
-        var collectLatencyEvent = function collectLatencyEvent(probe){
+        function collectLatencyEvent(probe){
 
             var eventNs = '.probe-' + probe.name;
 
@@ -160,33 +179,9 @@ define([
                 var listen = eventName.indexOf('.') > 0 ? eventName : eventName + eventNs;
                 runner.on(listen, _.partial(stopHandler, eventName));
             });
-        };
-
-        /**
-         * Get the storage instance
-         * @returns {Promise} that resolves with the storage
-         */
-        var getStorage = function getStorage(){
-            if(queueStorage){
-                return Promise.resolve(queueStorage);
-            }
-            return store('test-probe-' + testIdentifier).then(function(newStorage){
-                queueStorage = newStorage;
-                return Promise.resolve(queueStorage);
-            });
-        };
-
-        /**
-         * Unset the storage instance
-         */
-        var resetStorage = function resetStorage() {
-            queueStorage = null;
-        };
+        }
 
         //argument validation
-        if(_.isEmpty(testIdentifier)){
-            throw new TypeError('Please set a test identifier');
-        }
         if(!_.isPlainObject(runner) || !_.isFunction(runner.init) || !_.isFunction(runner.on)){
             throw new TypeError('Please set a test runner');
         }

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -27,8 +27,8 @@ define([
     'core/promise',
     'core/logger',
     'core/providerRegistry',
-    'taoTests/runner/dataHolder'
-], function ($, _, __, eventifier, Promise, logger, providerRegistry, dataHolderFactory){
+    'taoTests/runner/dataHolder',
+], function ($, _, __, eventifier, Promise, logger, providerRegistry, dataHolderFactory) {
     'use strict';
 
     /**
@@ -96,6 +96,12 @@ define([
          * @see taoTests/runner/probeOverseer
          */
         var probeOverseer;
+
+        /**
+         * Keep the instance of a testStore
+         * @see taoTests/runner/testStore
+         */
+        var testStore;
 
         /**
          * Run a method of the provider (by delegation)
@@ -447,6 +453,35 @@ define([
 
                 return probeOverseer;
             },
+
+            /**
+             * Get the testStore, and load it if not present
+             *
+             * @returns {testStore} the testStore instance
+             */
+            getTestStore : function getTestStore(){
+
+                if(!testStore && _.isFunction(provider.loadTestStore)){
+                    testStore = provider.loadTestStore.call(this);
+                }
+                return testStore;
+            },
+
+            /**
+             * Get a plugin store.
+             * It's a convenience method that calls testStore.getStore
+             * @param {String} name - the name of store, usually the plugin name.
+             *
+             * @returns {Promise<storage>} the plugin store
+             */
+            getPluginStore : function getPluginStore(name){
+                var loadedStore = this.getTestStore();
+                if(!loadedStore || !_.isFunction(loadedStore.getStore)){
+                    return Promise.reject(new Error('Please configure a testStore via loadTestStore to be able to get a plugin store'));
+                }
+                return this.getTestStore().getStore(name);
+            },
+
 
             /**
              * Check a runner state

--- a/views/js/runner/testStore.js
+++ b/views/js/runner/testStore.js
@@ -46,7 +46,7 @@ define([
      * @type {String[]}
      */
     var legacyPrefixes = [
-        'actions-', 'duration-', 'test-probes', 'timer-'
+        'actions-', 'duration-', 'test-probe', 'timer-'
     ];
     /**
      * Check and select the store mode.

--- a/views/js/runner/testStore.js
+++ b/views/js/runner/testStore.js
@@ -1,0 +1,295 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA
+ *
+ */
+
+/**
+ * The test runner persistent data store,
+ * to be used with sub stores.
+ *
+ * Supports the legacy mode where multiple stores were used by each plugin.
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/promise',
+    'core/store',
+    'core/logger'
+], function (_, Promise, store, loggerFactory) {
+    'use strict';
+
+    /**
+     * The test store logger
+     * @type {core/logger}
+     */
+    var logger = loggerFactory('taoQtiTest/runner/provider/testStore');
+
+    /**
+     * Database name prefix (suffixed by the test identifier)
+     * to check if we use the legacy mode (multiple dbs)
+     * or the new mode (one db per test).
+     * @type {String[]}
+     */
+    var legacyPrefixes = [
+        'actions-', 'duration-', 'test-states-', 'test-probes', 'timer-'
+    ];
+    /**
+     * Check and select the store mode.
+     * If any of the "legacyPrefixes" store is found, we used the "multiple/legacy" mode
+     * otherwise we use the unified mode.
+     * @param {String} testId
+     * @param {Object} [preselectedBackend] - the storage backend
+     * @returns {Promise<Boolean>} true means unified
+     */
+    var selectStoreMode = function selectStoreMode(testId, preselectedBackend){
+        return store
+            .getAll(function validate(storeName){
+                return _.some(legacyPrefixes, function(prefix){
+                    return !_.isEmpty(storeName) && prefix + testId === storeName;
+                });
+            }, preselectedBackend)
+            .then(function(foundStores){
+                return _.isArray(foundStores) && foundStores.length === 0;
+            });
+    };
+
+
+    /**
+     * Get the store for the given test
+     *
+     * @param {String} testId - unique test instance id
+     * @returns {testStore} a 'wrapped' store instance
+     * @param {Object} [preselectedBackend] - the storage backend (automatically selected by default)
+     * @throws {TypeError} with no testId
+     */
+    return function testStoreLoader(testId, preselectedBackend){
+
+        var storeNames = [];
+        var volatiles = [];
+        var unifiedStore;
+
+        var getMode = Promise.resolve();
+        if(_.isUndefined(unifiedStore)){
+            getMode = selectStoreMode(testId, preselectedBackend).then(function(result){
+                unifiedStore = !!result;
+
+                logger.debug('Test store mode ' + (unifiedStore ? 'unified' : 'multiple (legacy)') + ' for ' + testId);
+                console.log('Test store mode ' + (unifiedStore ? 'unified' : 'multiple (legacy)') + ' for ' + testId);
+            });
+        }
+
+        if(_.isEmpty(testId)){
+            throw new TypeError('The store must be identified with a unique test identifier');
+        }
+
+        /**
+         * Wraps a store and add the support of "volatile" storages
+         * @typedef {Object} testStore
+         */
+        return {
+
+            /**
+             * Get a wrapped store instance, that let's you use multiple stores inside one store...
+             * (or in multiple stores if the test is in legacy mode)
+             * @param {String} storeName - the name of the sub store
+             * @returns {Promise<storage>}
+             */
+            getStore : function getStore(storeName) {
+                if(_.isEmpty(storeName)){
+                    throw new TypeError('A store name must be provided to get the store');
+                }
+
+                if(!_.contains(storeNames, storeName)){
+                    storeNames.push(storeName);
+                }
+                return getMode.then(function(){
+                    if (unifiedStore) {
+                        return store(testId, preselectedBackend);
+                    } else {
+
+                        return store(storeName + '-' + testId, preselectedBackend);
+                    }
+                })
+                .then(function(loadedStore){
+                    var keyPattern = new RegExp('^' + storeName + '__');
+                    var storeKey = function storeKey(key){
+                        return unifiedStore ? storeName + '__' + key : key;
+                    };
+
+                    /**
+                     * The wrapped storage
+                     * @type {Object}
+                     */
+                    return {
+
+
+                        /**
+                         * Get an item with the given key
+                         * @param {String} key
+                         * @returns {Promise<*>} with the result in resolve, undefined if nothing
+                         */
+                        getItem : function getItem(key){
+                            return loadedStore.getItem(storeKey(key));
+                        },
+
+                        /**
+                         * Get all store items
+                         * @returns {Promise<Object>} with a collection of items
+                         */
+                        getItems : function getItems(){
+                            if(unifiedStore){
+                                return loadedStore.getItems().then(function(entries){
+                                    return _.transform(entries, function(acc, entry, key){
+                                        if(keyPattern.test(key)){
+                                            acc[key.replace(keyPattern, '')] = entry;
+                                        }
+                                        return acc;
+                                    }, {});
+                                });
+                            } else {
+                                return loadedStore.getItems();
+                            }
+                        },
+
+                        /**
+                         * Set an item with the given key
+                         * @param {String} key - the item key
+                         * @param {*} value - the item value
+                         * @returns {Promise<Boolean>} with true in resolve if added/updated
+                         */
+                        setItem : function setItem(key, value){
+                            return loadedStore.setItem(storeKey(key), value);
+                        },
+
+                        /**
+                         * Remove an item with the given key
+                         * @param {String} key - the item key
+                         * @returns {Promise<Boolean>} with true in resolve if removed
+                         */
+
+                        removeItem : function removeItem(key){
+                            return loadedStore.removeItem(storeKey(key));
+                        },
+
+                        /**
+                         * Clear the current store
+                         * @returns {Promise<Boolean>} with true in resolve once cleared
+                         */
+                        clear : function clear(){
+                            if(unifiedStore){
+                                return loadedStore.getItems()
+                                    .then(function(entries){
+                                        _.forEach(entries, function(entry, key){
+                                            if(keyPattern.test(key)){
+                                                loadedStore.removeItem(key);
+                                            }
+                                        });
+                                    });
+                            } else {
+                                return loadedStore.clear();
+                            }
+                        }
+                    };
+                });
+            },
+
+            /**
+             * Define the given store as "volatile".
+             * It means the store data can be revoked
+             * if the user change browser for example
+             * @param {String} storeName - the name of the store to set as volatile
+             * @returns {testStore} chains
+             */
+            setVolatile : function setVolatile(storeName){
+                if(!_.contains(volatiles, storeName)){
+                    volatiles.push(storeName);
+                }
+                return this;
+            },
+
+            /**
+             * Check the given storeId. If different from the current stored identifier
+             * we initiate the invalidation of the volatile data.
+             * @param {String} storeId - the id to check
+             * @returns {Promise<Boolean>} true if cleared
+             */
+            clearVolatileOnStoreChange : function clearVolatileOnStoreChange(storeId){
+                var self = this;
+                var shouldClear = false;
+                return store.getIdentifier(preselectedBackend)
+                    .then(function(savedStoreId){
+                        if (!_.isEmpty(storeId) && !_.isEmpty(savedStoreId) &&
+                            savedStoreId !== storeId ){
+
+                            shouldClear = true;
+                        }
+                        return shouldClear;
+                    })
+                    .then(function(clear){
+                        if(clear){
+                            return self.clearVolatileStores();
+                        }
+                        return false;
+                    });
+            },
+
+            /**
+             * Clear the storages marked as volatile
+             * @returns {Promise<Boolean>} true if cleared
+             */
+            clearVolatileStores : function clearVolatileStores(){
+                var self = this;
+                var clearing = volatiles.map(function(storeName){
+                    return self.getStore(storeName).then(function(storeInstance){
+                        return storeInstance.clear();
+                    });
+                });
+
+                return Promise.all(clearing).then(function(results){
+                    return results && results.length === volatiles.length;
+                });
+            },
+
+            /**
+             * Remove the whole store
+             * @returns {Promise<Boolean>} true if done
+             */
+            remove : function remove(){
+                var legacyStoreExp = new RegExp('-' + testId + '$');
+                return getMode.then(function(){
+                    if(unifiedStore){
+                        return store(testId, preselectedBackend).then(function(storeInstance){
+                            return storeInstance.removeStore();
+                        });
+                    }
+                    return store.removeAll(function(storeName){
+                        return legacyStoreExp.test(storeName);
+                    }, preselectedBackend);
+                });
+            },
+
+            /**
+             * Wraps the identifier retrieval
+             * @returns {Promise<String>} the current store id
+             */
+            getStorageIdentifier : function getStorageIdentifier(){
+                return store.getIdentifier(preselectedBackend);
+            }
+        };
+    };
+});

--- a/views/js/runner/testStore.js
+++ b/views/js/runner/testStore.js
@@ -89,7 +89,6 @@ define([
                 unifiedStore = !!result;
 
                 logger.debug('Test store mode ' + (unifiedStore ? 'unified' : 'multiple (legacy)') + ' for ' + testId);
-                console.log('Test store mode ' + (unifiedStore ? 'unified' : 'multiple (legacy)') + ' for ' + testId);
             });
         }
 
@@ -236,6 +235,7 @@ define([
                         if (!_.isEmpty(storeId) && !_.isEmpty(savedStoreId) &&
                             savedStoreId !== storeId ){
 
+                            logger.info('Storage change detected (' + savedStoreId + ' != ' + storeId + ') => volatiles data wipe out !');
                             shouldClear = true;
                         }
                         return shouldClear;

--- a/views/js/runner/testStore.js
+++ b/views/js/runner/testStore.js
@@ -46,7 +46,7 @@ define([
      * @type {String[]}
      */
     var legacyPrefixes = [
-        'actions-', 'duration-', 'test-states-', 'test-probes', 'timer-'
+        'actions-', 'duration-', 'test-probes', 'timer-'
     ];
     /**
      * Check and select the store mode.

--- a/views/js/test/runner/probeOverseer/test.js
+++ b/views/js/test/runner/probeOverseer/test.js
@@ -47,9 +47,13 @@ define([
                         }, 10);
                     });
                 },
-                removeStore : function removeStore(){
-                    mockedData = {};
-                    return Promise.resolve(true);
+                removeItem : function removeItem(key){
+                    return new Promise(function(resolve){
+                        setTimeout(function(){
+                            delete mockedData[key];
+                            resolve(true);
+                        }, 5);
+                    });
                 }
             });
         }

--- a/views/js/test/runner/probeOverseer/test.js
+++ b/views/js/test/runner/probeOverseer/test.js
@@ -22,46 +22,68 @@
 define([
     'jquery',
     'lodash',
+    'core/promise',
     'taoTests/runner/runner',
     'taoTests/runner/probeOverseer'
-], function($, _, runnerFactory, probeOverseer) {
+], function($, _, Promise, runnerFactory, probeOverseer) {
     'use strict';
+
+    var mockedData = {};
+    var mockTestStore = {
+        getStore : function(){
+            return Promise.resolve({
+                getItem : function getItem(key){
+                    return new Promise(function(resolve){
+                        setTimeout(function(){
+                            resolve(mockedData[key]);
+                        }, 2);
+                    });
+                },
+                setItem : function setItem(key, value){
+                    return new Promise(function(resolve){
+                        setTimeout(function(){
+                            mockedData[key] = value;
+                            resolve(true);
+                        }, 10);
+                    });
+                },
+                removeStore : function removeStore(){
+                    mockedData = {};
+                    return Promise.resolve(true);
+                }
+            });
+        }
+    };
 
     var mockRunner = {
         init: _.noop,
-        on: _.noop
+        on: _.noop,
+        getTestStore : mockTestStore
     };
-
 
     QUnit.module('API');
 
     QUnit.test('module factory', function(assert) {
-        var testId = 'test-1';
 
-        QUnit.expect(6);
+        QUnit.expect(5);
 
         assert.equal(typeof probeOverseer, 'function', "The module exposes a function");
 
         assert.throws(function() {
             probeOverseer();
-        }, TypeError, "The factory needs a test id");
-
-        assert.throws(function() {
-            probeOverseer(testId);
         }, TypeError, "The factory needs a runner");
 
         assert.throws(function() {
-            probeOverseer(testId, {});
+            probeOverseer({});
         }, TypeError, "The factory needs a valid runner");
 
-        assert.equal(typeof probeOverseer(testId, mockRunner), 'object', "The module is a factory");
-        assert.notEqual(probeOverseer(testId, mockRunner), probeOverseer(testId, mockRunner), "The factory creates different instances");
+        assert.equal(typeof probeOverseer(mockRunner), 'object', "The module is a factory");
+        assert.notEqual(probeOverseer(mockRunner), probeOverseer(mockRunner), "The factory creates different instances");
     });
 
 
     QUnit.test('own api', function(assert) {
-        var testId = 'test-2';
-        var probes = probeOverseer(testId, mockRunner);
+        var probes = probeOverseer(mockRunner);
 
         QUnit.expect(7);
 
@@ -74,11 +96,14 @@ define([
         assert.equal(typeof probes.stop, 'function', "The module as the stop method");
     });
 
-    QUnit.module('probes');
+    QUnit.module('probes', {
+        teardown : function(){
+            mockedData = {};
+        }
+    });
 
     QUnit.test('normal validation', function(assert) {
-        var testId = 'test-3';
-        var probes = probeOverseer(testId, mockRunner);
+        var probes = probeOverseer(mockRunner);
 
         QUnit.expect(5);
 
@@ -117,8 +142,7 @@ define([
     });
 
     QUnit.test('latency validation', function(assert) {
-        var testId = 'test-4';
-        var probes = probeOverseer(testId, mockRunner);
+        var probes = probeOverseer(mockRunner);
 
         QUnit.expect(4);
 
@@ -159,8 +183,7 @@ define([
     });
 
     QUnit.test('add and get', function(assert) {
-        var testId = 'test-5';
-        var probes = probeOverseer(testId, mockRunner);
+        var probes = probeOverseer(mockRunner);
         var p1 = {
             name: 'foo',
             latency: true,
@@ -180,8 +203,7 @@ define([
     });
 
     QUnit.test('reformat events', function(assert) {
-        var testId = 'test-6';
-        var probes = probeOverseer(testId, mockRunner);
+        var probes = probeOverseer(mockRunner);
         var p1 = {
             name: 'foo',
             latency: true,
@@ -206,23 +228,28 @@ define([
     QUnit.module('collection', {
         setup: function() {
             runnerFactory.clearProviders();
+        },
+        teardown : function(){
+            mockedData = {};
         }
     });
 
     QUnit.asyncTest('simple', function(assert) {
-        var testId = 'test-7';
         var runner, probes;
 
         QUnit.expect(14);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.add({
             name: 'test-ready',
@@ -277,19 +304,21 @@ define([
     });
 
     QUnit.asyncTest('simple(param)', function(assert) {
-        var testId = 'test-8';
         var runner, probes;
 
         QUnit.expect(15);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.add({
             name: 'test-param',
@@ -346,19 +375,21 @@ define([
     });
 
     QUnit.asyncTest('latency', function(assert) {
-        var testId = 'test-9';
         var runner, probes;
 
         QUnit.expect(20);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.add({
             name: 'test-latency',
@@ -428,19 +459,21 @@ define([
     });
 
     QUnit.asyncTest('latency(param)', function(assert) {
-        var testId = 'test-10';
         var runner, probes;
 
         QUnit.expect(22);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.add({
             name: 'test-latency',
@@ -512,19 +545,21 @@ define([
     });
 
     QUnit.asyncTest('flush', function(assert) {
-        var testId = 'test-11';
         var runner, probes;
 
         QUnit.expect(3);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.add({
             name: 'foo',
@@ -571,19 +606,21 @@ define([
     });
 
     QUnit.asyncTest('stop', function(assert) {
-        var testId = 'test-12';
         var runner, probes;
 
         QUnit.expect(2);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.add({
             name: 'foo',
@@ -624,19 +661,21 @@ define([
     });
 
     QUnit.asyncTest('concurrency', function(assert) {
-        var testId = 'test-13';
         var runner, probes;
 
         QUnit.expect(3);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
+            loadTestStore : function(){
+                return mockTestStore;
+            },
             init: _.noop
         });
 
         runner = runnerFactory('foo');
 
-        probes = probeOverseer(testId, runner);
+        probes = probeOverseer(runner);
 
         probes.start()
             .then(function(){
@@ -654,8 +693,7 @@ define([
                 return flushPromise;
             })
             .catch(function(e) {
-                assert.ok(false, 'An error occurred');
-                console.error(e);
+                assert.ok(false, 'An error occurred : ' + e.message);
                 QUnit.start();
             });
     });

--- a/views/js/test/runner/testStore/test.html
+++ b/views/js/test/runner/testStore/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test Runner - Navigator</title>
+        <base href="../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="runner/testStore.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['taoTests/test/runner/testStore/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/runner/testStore/test.html
+++ b/views/js/test/runner/testStore/test.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Test Runner - Navigator</title>
+        <title>Test Runner - TestStore</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <script type="text/javascript" src="js/lib/require.js"></script>

--- a/views/js/test/runner/testStore/test.js
+++ b/views/js/test/runner/testStore/test.js
@@ -100,7 +100,7 @@ define([
     }, {
         title: 'setVolatile'
     }, {
-        title: 'clearVolatileOnStoreChange'
+        title: 'clearVolatileIfStoreChange'
     }, {
         title: 'clearVolatileStores'
     }, {
@@ -447,7 +447,7 @@ define([
         testStore.setVolatile('store-1');
         testStore.setVolatile('store-2');
 
-        testStore.clearVolatileOnStoreChange('unit-test')
+        testStore.clearVolatileIfStoreChange('unit-test')
             .then(function(){
                 assert.deepEqual(mockedData, {
                     '1234' : {
@@ -465,7 +465,7 @@ define([
                     }
                 }, 'Data marked as volatile should not be removed, no store change');
 
-                return testStore.clearVolatileOnStoreChange('ABCDE');
+                return testStore.clearVolatileIfStoreChange('ABCDE');
             })
             .then(function(){
                 assert.deepEqual(mockedData, {

--- a/views/js/test/runner/testStore/test.js
+++ b/views/js/test/runner/testStore/test.js
@@ -1,0 +1,616 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Test the module {@link taoTests/runner/testStore}
+ *
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'taoTests/runner/testStore',
+], function(testStoreLoader) {
+    'use strict';
+
+    var mockedData = {};
+    var mockBackend = function(name){
+
+        if(!name){
+            throw new TypeError('no name');
+        }
+        mockedData[name] = mockedData[name] || {};
+        return {
+            getItem : function getItem(key){
+                return Promise.resolve(mockedData[name][key]);
+            },
+            setItem : function setItem(key, value){
+                mockedData[name][key] = value;
+                return Promise.resolve(true);
+            },
+            getItems : function getItems(){
+                return Promise.resolve(mockedData[name]);
+            },
+            removeItem : function removeItem(key){
+                delete mockedData[name][key];
+                return Promise.resolve(true);
+            },
+            clear : function clear(){
+                mockedData[name] = {};
+                return Promise.resolve(true);
+            },
+            removeStore : function removeStore(){
+                delete mockedData[name];
+                return Promise.resolve(true);
+            }
+        };
+    };
+    mockBackend.removeAll = function(){};
+    mockBackend.getAll = function(){
+        return [];
+    };
+    mockBackend.getStoreIdentifier = function(){
+        return 'unit-test';
+    };
+
+
+    QUnit.module('API');
+
+    QUnit.test('module', function(assert) {
+        QUnit.expect(1);
+
+        assert.equal(typeof testStoreLoader, 'function', "The module exposes a function");
+    });
+
+    QUnit.test('loader', function(assert) {
+        QUnit.expect(4);
+
+        assert.throws(function() {
+            testStoreLoader();
+        }, TypeError, 'loader called without parameter');
+
+        assert.throws(function() {
+            testStoreLoader(null);
+        }, TypeError, 'loader called with null parameter');
+
+        assert.throws(function() {
+            testStoreLoader('');
+        }, TypeError, 'loader called with empty parameter');
+
+
+        assert.equal(typeof testStoreLoader('test-1234', mockBackend), 'object', "The loader returns an object");
+    });
+
+    QUnit.cases([{
+        title: 'getStore'
+    }, {
+        title: 'setVolatile'
+    }, {
+        title: 'clearVolatileOnStoreChange'
+    }, {
+        title: 'clearVolatileStores'
+    }, {
+        title: 'remove'
+    }])
+    .test('testStore API ', function(data, assert) {
+        QUnit.expect(1);
+        assert.equal(typeof testStoreLoader('test-1234', mockBackend)[data.title], 'function', 'The instance exposes a "' + data.title + '" method');
+    });
+
+
+
+    QUnit.module('Store selection', {
+        teardown : function(){
+            mockedData = {};
+            mockBackend.getAll = function(){
+                return [];
+            };
+        }
+    });
+
+    QUnit.asyncTest('get store', function(assert){
+        var testStore;
+
+        QUnit.expect(7);
+
+        testStore = testStoreLoader('test-1234', mockBackend);
+
+        assert.throws(function(){
+            testStore.getStore();
+        }, TypeError, 'A store name must be provided');
+
+        testStore.getStore('foo')
+            .then(function(store){
+                assert.equal(typeof store, 'object', 'The retrieved store is an object');
+                assert.equal(typeof store.getItem, 'function', 'The retrieved store API match the storage');
+                assert.equal(typeof store.getItems, 'function', 'The retrieved store API match the storage');
+                assert.equal(typeof store.setItem, 'function', 'The retrieved store API match the storage');
+                assert.equal(typeof store.removeItem, 'function', 'The retrieved store API match the storage');
+                assert.equal(typeof store.clear, 'function', 'The retrieved store API match the storage');
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('select legacy mode', function(assert){
+        var testStore;
+
+        QUnit.expect(5);
+
+        mockBackend.getAll = function(validate){
+            assert.ok(true, 'get all is called to select the mode');
+            return [
+                'duration-123456',
+                'duration-abcde',
+                'duration-foobar',
+                'test-states-123456',
+                'timer-abcde'
+            ].filter(validate);
+        };
+        testStore = testStoreLoader('abcde', mockBackend);
+
+        assert.equal(typeof mockedData['foo-abcde'], 'undefined');
+        testStore.getStore('foo')
+            .then(function(store){
+                assert.equal(typeof mockedData['foo-abcde'], 'object', 'A legacy like store is created');
+                assert.equal(typeof mockedData['foo-abcde']['moo'], 'undefined', 'The value is not in the store');
+
+                return store.setItem('moo', 'too');
+            })
+            .then(function(){
+
+                assert.equal(mockedData['foo-abcde']['moo'], 'too', 'The value is set in the legacy like store');
+
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('select unified mode', function(assert){
+        var testStore;
+
+        QUnit.expect(6);
+
+        mockBackend.getAll = function(validate){
+            assert.ok(true, 'get all is called to select the mode');
+            return [
+                'duration-123456',
+                'duration-abcde',
+                'duration-foobar',
+                'test-states-123456',
+                'timer-abcde'
+            ].filter(validate);
+        };
+        testStore = testStoreLoader('AF16B4', mockBackend);
+
+        assert.equal(typeof mockedData['AF16B4'], 'undefined');
+
+        testStore.getStore('foo')
+            .then(function(store){
+                assert.equal(typeof mockedData['foo-AF16B4'], 'undefined', 'No legacy like store');
+                assert.equal(typeof mockedData['AF16B4'], 'object', 'The unified store is created');
+                assert.equal(typeof mockedData['AF16B4']['foo__moo'], 'undefined', 'The store has not the value');
+
+                return store.setItem('moo', 'too');
+            })
+            .then(function(){
+
+                assert.equal(mockedData['AF16B4']['foo__moo'], 'too', 'The value is set in the unified store, prefixed');
+
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.module('Store CRUD', {
+        teardown : function(){
+            mockedData = {};
+            mockBackend.getAll = function(){
+                return [];
+            };
+        }
+    });
+
+    QUnit.asyncTest('legacy mode', function(assert){
+        var testStore;
+
+        QUnit.expect(14);
+
+        mockBackend.getAll = function(validate){
+            assert.ok(true, 'get all is called to select the mode');
+            return [
+                'duration-123456',
+            ].filter(validate);
+        };
+        testStore = testStoreLoader('123456', mockBackend);
+
+        assert.equal(typeof mockedData['timer-123456'], 'undefined');
+
+        testStore.getStore('timer')
+            .then(function(store){
+                assert.equal(typeof mockedData['timer-123456'], 'object', 'A legacy like store is created');
+
+                assert.equal(typeof mockedData['timer-123456']['time'], 'undefined', 'The value is not in the store');
+                assert.equal(typeof mockedData['timer-123456']['state'], 'undefined', 'The value is not in the store');
+
+                return Promise.all([
+                    store.setItem('time', 12),
+                    store.setItem('state', 'started')
+                ])
+                .then(function(){
+                    assert.equal(mockedData['timer-123456']['time'], 12, 'The value is set in the store');
+                    assert.equal(mockedData['timer-123456']['state'], 'started', 'The value is set in the store');
+
+                    return Promise.all([
+                        store.getItem('time'),
+                        store.getItem('state')
+                    ]);
+                })
+                .then(function(results){
+                    assert.equal(results[0], 12, 'The retrieved value macthes the set value');
+                    assert.equal(results[1], 'started', 'The retrieved value macthes the set value');
+
+                    return store.getItems();
+                })
+                .then(function(results){
+                    assert.equal(results.time, 12, 'The entry is retreived');
+                    assert.equal(results.state, 'started', 'The entry is retreived');
+
+                    return store.removeItem('state');
+                })
+                .then(function(){
+                    assert.equal(mockedData['timer-123456']['time'], 12, 'The value is set in the store');
+                    assert.equal(typeof mockedData['timer-123456']['state'], 'undefined', 'The value has been removed');
+
+                    return store.clear();
+                })
+                .then(function(){
+                    assert.deepEqual(mockedData['timer-123456'], {}, 'The store is empty');
+                });
+            })
+            .then(function(){
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('unified mode', function(assert){
+        var testStore;
+
+        QUnit.expect(13);
+
+        testStore = testStoreLoader('123456', mockBackend);
+
+        assert.equal(typeof mockedData['123456'], 'undefined');
+
+        testStore.getStore('timer')
+            .then(function(store){
+                assert.equal(typeof mockedData['123456'], 'object', 'A unified like store is created');
+
+                assert.equal(typeof mockedData['123456']['timer__time'], 'undefined', 'The value is not in the store');
+                assert.equal(typeof mockedData['123456']['timer__state'], 'undefined', 'The value is not in the store');
+
+                return Promise.all([
+                    store.setItem('time', 12),
+                    store.setItem('state', 'started')
+                ])
+                .then(function(){
+                    assert.equal(mockedData['123456']['timer__time'], 12, 'The value is set in the store');
+                    assert.equal(mockedData['123456']['timer__state'], 'started', 'The value is set in the store');
+
+                    return Promise.all([
+                        store.getItem('time'),
+                        store.getItem('state')
+                    ]);
+                })
+                .then(function(results){
+                    assert.equal(results[0], 12, 'The retrieved value macthes the set value');
+                    assert.equal(results[1], 'started', 'The retrieved value macthes the set value');
+
+                    return store.getItems();
+                })
+                .then(function(results){
+                    assert.equal(results.time, 12, 'The entry is retreived');
+                    assert.equal(results.state, 'started', 'The entry is retreived');
+
+                    return store.removeItem('state');
+                })
+                .then(function(){
+                    assert.equal(mockedData['123456']['timer__time'], 12, 'The value is set in the store');
+                    assert.equal(typeof mockedData['123456']['timer__state'], 'undefined', 'The value has been removed');
+
+                    return store.clear();
+                })
+                .then(function(){
+                    assert.deepEqual(mockedData['123456'], {}, 'The store is empty');
+                });
+            })
+            .then(function(){
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.module('volatiles', {
+        teardown: function(){
+            mockedData = {};
+            mockBackend.getAll = function(){
+                return [];
+            };
+        }
+    });
+
+    QUnit.asyncTest('clear volatiles stores', function(assert){
+        var testStore;
+
+        QUnit.expect(1);
+
+        mockedData = {
+            '1234' : {
+                'store-1__foo' : 'volatile',
+                'store-1__moo' : 'volatile',
+                'store-2__foo' : 'volatile',
+                'store-2__moo' : 'volatile',
+                'store-3__foo' : 'persistent',
+                'store-3__moo' : 'persistent'
+            },
+            'abcde' : {
+                'store-1__foo' : 'bar',
+                'store-1__moo' : 'bar',
+                'store-2__foo' : 'bar',
+                'store-2__moo' : 'bar',
+                'store-3__foo' : 'bar',
+                'store-3__moo' : 'bar'
+            },
+        };
+
+        testStore = testStoreLoader('1234', mockBackend);
+        testStore.setVolatile('store-1');
+        testStore.setVolatile('store-2');
+
+        testStore.clearVolatileStores()
+            .then(function(){
+                assert.deepEqual(mockedData, {
+                    '1234' : {
+                        'store-3__foo' : 'persistent',
+                        'store-3__moo' : 'persistent'
+                    },
+                    'abcde' : {
+                        'store-1__foo' : 'bar',
+                        'store-1__moo' : 'bar',
+                        'store-2__foo' : 'bar',
+                        'store-2__moo' : 'bar',
+                        'store-3__foo' : 'bar',
+                        'store-3__moo' : 'bar'
+                    }
+                }, 'Data marked as volatile is removed');
+
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('clear volatiles stores on store change', function(assert){
+        var testStore;
+
+        QUnit.expect(2);
+
+        mockedData = {
+            '1234' : {
+                'store-1__foo' : 'volatile',
+                'store-1__moo' : 'volatile',
+                'store-2__foo' : 'volatile',
+                'store-2__moo' : 'volatile',
+                'store-3__foo' : 'persistent',
+                'store-3__moo' : 'persistent'
+            },
+            'abcde' : {
+                'store-1__foo' : 'bar',
+                'store-2__foo' : 'bar',
+                'store-3__foo' : 'bar',
+            },
+        };
+
+        testStore = testStoreLoader('1234', mockBackend);
+        testStore.setVolatile('store-1');
+        testStore.setVolatile('store-2');
+
+        testStore.clearVolatileOnStoreChange('unit-test')
+            .then(function(){
+                assert.deepEqual(mockedData, {
+                    '1234' : {
+                        'store-1__foo' : 'volatile',
+                        'store-1__moo' : 'volatile',
+                        'store-2__foo' : 'volatile',
+                        'store-2__moo' : 'volatile',
+                        'store-3__foo' : 'persistent',
+                        'store-3__moo' : 'persistent'
+                    },
+                    'abcde' : {
+                        'store-1__foo' : 'bar',
+                        'store-2__foo' : 'bar',
+                        'store-3__foo' : 'bar',
+                    }
+                }, 'Data marked as volatile should not be removed, no store change');
+
+                return testStore.clearVolatileOnStoreChange('ABCDE');
+            })
+            .then(function(){
+                assert.deepEqual(mockedData, {
+                    '1234' : {
+                        'store-3__foo' : 'persistent',
+                        'store-3__moo' : 'persistent'
+                    },
+                    'abcde' : {
+                        'store-1__foo' : 'bar',
+                        'store-2__foo' : 'bar',
+                        'store-3__foo' : 'bar',
+                    }
+                }, 'Data marked as volatile is removed');
+
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.module('remove', {
+        teardown: function(){
+            mockedData = {};
+            mockBackend.removeAll = mockBackend.getAll = function(){
+                return [];
+            };
+        }
+    });
+
+    QUnit.asyncTest('legacy mode', function(assert){
+        var testStore;
+
+        QUnit.expect(12);
+
+        mockBackend.getAll = function(validate){
+            assert.ok(true, 'get all is called to select the mode');
+            return [
+                'duration-123456',
+            ].filter(validate);
+        };
+
+        mockBackend.removeAll = function(validate){
+            assert.ok(true, 'get all is called to select the mode');
+            Object
+                .keys(mockedData)
+                .filter(validate)
+                .forEach(function(storeName){
+                    assert.ok(storeName === 'timer-123456' || storeName === 'duration-123456');
+                    delete mockedData[storeName];
+                });
+            return true;
+        };
+        testStore = testStoreLoader('123456', mockBackend);
+
+        assert.equal(typeof mockedData['timer-123456'], 'undefined', 'The store does not exists');
+        assert.equal(typeof mockedData['duration-123456'], 'undefined', 'The store does not exists');
+
+        testStore.getStore('timer')
+            .then(function(store){
+                return Promise.all([
+                    store.setItem('time', 12),
+                    store.setItem('state', 'started')
+                ]);
+            })
+            .then(function(){
+                return testStore.getStore('duration');
+            })
+            .then(function(store){
+                return Promise.all([
+                    store.setItem('elapsed', 124),
+                    store.setItem('item', '456789')
+                ]);
+            })
+            .then(function(){
+
+                assert.equal(mockedData['timer-123456']['time'], 12, 'The value is set in the store');
+                assert.equal(mockedData['timer-123456']['state'], 'started', 'The value is set in the store');
+                assert.equal(mockedData['duration-123456']['elapsed'], 124, 'The value is set in the store');
+                assert.equal(mockedData['duration-123456']['item'], '456789', 'The value is set in the store');
+            })
+            .then(function(){
+                return testStore.remove();
+            })
+            .then(function(){
+                assert.equal(typeof mockedData['timer-123456'], 'undefined', 'The store is removed');
+                assert.equal(typeof mockedData['duration-123456'], 'undefined', 'The store is removed');
+            })
+            .then(function(){
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest('unified mode', function(assert){
+        var testStore;
+
+        QUnit.expect(6);
+
+        testStore = testStoreLoader('123456', mockBackend);
+
+        assert.equal(typeof mockedData['123456'], 'undefined');
+
+        testStore.getStore('timer')
+            .then(function(store){
+                return Promise.all([
+                    store.setItem('time', 12),
+                    store.setItem('state', 'started')
+                ]);
+            })
+            .then(function(){
+                return testStore.getStore('duration');
+            })
+            .then(function(store){
+                return Promise.all([
+                    store.setItem('elapsed', 124),
+                    store.setItem('item', '456789')
+                ]);
+            })
+            .then(function(){
+
+                assert.equal(mockedData['123456']['timer__time'], 12, 'The value is set in the store');
+                assert.equal(mockedData['123456']['timer__state'], 'started', 'The value is set in the store');
+                assert.equal(mockedData['123456']['duration__elapsed'], 124, 'The value is set in the store');
+                assert.equal(mockedData['123456']['duration__item'], '456789', 'The value is set in the store');
+            })
+            .then(function(){
+                return testStore.remove();
+            })
+            .then(function(){
+                assert.equal(typeof mockedData['123456'], 'undefined', 'The store is removed');
+            })
+            .then(function(){
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+});

--- a/views/js/test/runner/testStore/test.js
+++ b/views/js/test/runner/testStore/test.js
@@ -160,7 +160,6 @@ define([
                 'duration-123456',
                 'duration-abcde',
                 'duration-foobar',
-                'test-states-123456',
                 'timer-abcde'
             ].filter(validate);
         };
@@ -197,7 +196,6 @@ define([
                 'duration-123456',
                 'duration-abcde',
                 'duration-foobar',
-                'test-states-123456',
                 'timer-abcde'
             ].filter(validate);
         };


### PR DESCRIPTION
_No rush on this, it's an old story I had the time to finish. Please take the time to perform additional tests_

Add a new module called the **testStore** it provides a unified store for the test runner and the plugin. The goal is to store all the data of a test in one store, and to hide the store management to the implementation logic. 
 - New method `getTestStore`  on the test runner instance. Gives you an instance of the test store.
 - New method `getPluginStore`  on the test runner instance. It's a convenience method to get a store inside a plugin. The given store will be managed like a dedicated store but will save and retrieve the data from the unified store.
 - Test runner providers have to implement the method `loadTestStore` if they want to manipulate a store
 - The testStore supports running tests (legacy mode) and will fallback to the old way to store data if needed (please test also this point)
 - The testStore takes care of the _volatile_ stores. No need anymore to listen for the event `storechange` to clear the store. The only action required is to declare the store (or sub store) as _volatile_. 


**Requires**
- [ ] https://github.com/oat-sa/tao-core/pull/1621

**Companion PRs**
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1204
 - [ ] https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/46
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/895 (optional)