### PR TITLE
Feature/tao 6221 allow late submission

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '7.9.0',
+    'version' => '7.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -154,7 +154,7 @@ class Updater extends \common_ext_ExtensionUpdater
             }
             $this->setVersion('7.8.0');
         }
-        
-        $this->skip('7.8.0', '7.9.0');
+
+        $this->skip('7.8.0', '7.10.0');
     }
 }

--- a/views/js/runner/runner.js
+++ b/views/js/runner/runner.js
@@ -744,13 +744,14 @@ define([
 
             /**
              * Notify a test timeout
-             * @param {String} scope
-             * @param {String} ref
+             * @param {String} scope - The scope where the timeout occurred
+             * @param {String} ref - The reference to the place where the timeout occurred
+             * @param {Object} [timer] - The timer's descriptor, if any
              * @fires runner#timeout
              * @returns {runner} chains
              */
-            timeout : function timeout(scope, ref){
-                this.trigger('timeout', scope, ref);
+            timeout : function timeout(scope, ref, timer){
+                this.trigger('timeout', scope, ref, timer);
                 return this;
             }
         });

--- a/views/js/test/runner/runner/test.js
+++ b/views/js/test/runner/runner/test.js
@@ -660,8 +660,11 @@ define([
     QUnit.asyncTest('timeout', function(assert){
         var expectedScope = 'assessmentSection';
         var expectedRef = 'assessmentSection-1';
+        var expectedTimer = {
+            time: 30
+        };
 
-        QUnit.expect(4);
+        QUnit.expect(5);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker : _.noop,
@@ -669,13 +672,14 @@ define([
 
                 this.on('init', function(){
                     assert.ok(true, 'we can listen for init in providers init');
-                    this.timeout(expectedScope, expectedRef);
+                    this.timeout(expectedScope, expectedRef, expectedTimer);
                 })
-                .on('timeout', function(scope, ref){
+                .on('timeout', function(scope, ref, timer){
                     assert.ok(true, 'The timeout event has been triggered');
 
                     assert.equal(scope, expectedScope, 'The timeout scope is provided');
                     assert.equal(ref, expectedRef, 'The timeout ref is provided');
+                    assert.equal(timer, expectedTimer, 'The timer is provided');
 
                     QUnit.start();
                 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-6221

Add a parameter to the timeout API in the test runner. This is needed to get info on which timer has triggered the timeout. However this new parameter is optional and depends on the implemented provider.