### PR TITLE
add tracking changes in the test runner store

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '8.1.0',
+    'version' => '8.2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '8.2.0',
+    'version' => '8.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -156,6 +156,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.8.0');
         }
 
-        $this->skip('7.8.0', '8.2.0');
+        $this->skip('7.8.0', '8.3.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -156,6 +156,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.8.0');
         }
 
-        $this->skip('7.8.0', '8.1.0');
+        $this->skip('7.8.0', '8.2.0');
     }
 }

--- a/views/js/test/runner/testStore/test.js
+++ b/views/js/test/runner/testStore/test.js
@@ -105,6 +105,12 @@ define([
         title: 'clearVolatileStores'
     }, {
         title: 'remove'
+    }, {
+        title: 'trackChanges'
+    }, {
+        title: 'hasChanges'
+    }, {
+        title: 'resetChanges'
     }])
     .test('testStore API ', function(data, assert) {
         QUnit.expect(1);
@@ -604,6 +610,68 @@ define([
                 assert.equal(typeof mockedData['123456'], 'undefined', 'The store is removed');
             })
             .then(function(){
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.module('Changes', {
+        teardown: function(){
+            mockedData = {};
+            mockBackend.getAll = function(){
+                return [];
+            };
+        }
+    });
+
+    QUnit.asyncTest('track changes', function(assert){
+        var testStore;
+
+        QUnit.expect(10);
+
+        testStore = testStoreLoader('789456', mockBackend);
+        testStore.trackChanges('store-A');
+        testStore.trackChanges('store-B');
+
+        assert.equal(testStore.hasChanges('store-A'), false, 'The store-A has no changes');
+        assert.equal(testStore.hasChanges('store-B'), false, 'The store-B has no changes');
+
+        testStore.getStore('store-A')
+            .then(function(storeA){
+                return storeA.setItem('foo', 123);
+            })
+            .then(function(){
+
+                assert.equal(testStore.hasChanges('store-A'), true, 'The store-A has some changes');
+                assert.equal(testStore.hasChanges('store-B'), false, 'The store-B has no changes');
+
+                testStore.resetChanges('store-A');
+
+                assert.equal(testStore.hasChanges('store-A'), false, 'The store-A has no changes anymore');
+                assert.equal(testStore.hasChanges('store-B'), false, 'The store-B has no changes');
+
+                return testStore.getStore('store-A');
+            })
+            .then(function(storeA){
+                return storeA.getItem('elapsed', 124);
+            })
+            .then(function(){
+                assert.equal(testStore.hasChanges('store-A'), false, 'The store-A still has no changes');
+                assert.equal(testStore.hasChanges('store-B'), false, 'The store-B has no changes');
+
+                return testStore.getStore('store-A');
+            })
+            .then(function(storeA){
+                return storeA.removeItem('foo');
+            })
+            .then(function(){
+                assert.equal(testStore.hasChanges('store-A'), true, 'The store-A has some changes');
+                assert.equal(testStore.hasChanges('store-B'), false, 'The store-B has no changes');
+
                 QUnit.start();
             })
             .catch(function(err){


### PR DESCRIPTION
 The goal of this PR is to brign a feature to the test runner's store that let's you track changes on a given store. 
 The end goal is to track changes in the plugins configured to restore their state in from the server and send their state only if some changes have been made.

This pull request is validated using tests.