### PR TITLE
Feature/remove random bytes compat lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,16 +48,13 @@
         "tao-extension-name": "taoTests"
     },
     "require": {
-        "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "paragonie/random_compat": "^2.0"
-
+        "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
     },
     "autoload": {
         "psr-4": {
             "oat\\taoTests\\models\\": "models/classes/",
             "oat\\taoTests\\test\\": "test",
             "oat\\taoTests\\scripts\\": "scripts"
-
         }
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -31,13 +31,13 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '8.3.2',
+    'version' => '8.4.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',
         'taoItems' => '>=6.0.0',
         'taoBackOffice' => '>=3.0.0',
-        'tao' => '>=21.0.0'
+        'tao' => '>=22.14.6'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -135,6 +135,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.8.0');
         }
 
-        $this->skip('7.8.0', '8.3.2');
+        $this->skip('7.8.0', '8.4.0');
     }
 }


### PR DESCRIPTION
Requires : 
 - [ ] https://github.com/oat-sa/tao-core/pull/1954

Remove `paragonie/random_compat` since it is not required anymore since version `6.0.0` and the dependency has been moved to tao-core