### PR TITLE
Feature/nex 19 test provider registry

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '12.0.0',
+    'version' => '12.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',

--- a/models/classes/runner/providers/ProviderRegistry.php
+++ b/models/classes/runner/providers/ProviderRegistry.php
@@ -72,8 +72,7 @@ class ProviderRegistry extends AbstractModuleRegistry
      */
     public function removeByCategory($category = null)
     {
-        $providers = $this->getByCategory($category);
-        foreach ($providers as $provider) {
+        foreach ($this->getByCategory($category) as $provider) {
             if (isset($provider['module'])) {
                 $this->remove($provider['module']);
             }

--- a/models/classes/runner/providers/ProviderRegistry.php
+++ b/models/classes/runner/providers/ProviderRegistry.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoTests\models\runner\providers;
@@ -45,5 +45,38 @@ class ProviderRegistry extends AbstractModuleRegistry
     protected function getExtension()
     {
         return common_ext_ExtensionsManager::singleton()->getExtensionById('taoTests');
+    }
+
+    /**
+     * Get all modules that belong to a category
+     * @param string $category - the provider category (runner, proxy,etc.)
+     * @return array the matching providers
+     */
+    public function getByCategory($category = null)
+    {
+        if (is_null($category)) {
+            return [];
+        }
+
+        return array_filter(
+            $this->getMap(),
+            function($provider) use ($category) {
+                return isset($provider['category']) && $provider['category'] == $category;
+            }
+        );
+    }
+
+    /**
+     * Unregister all modules that belong to a category
+     * @param string $category - the provider category (runner, proxy,etc.)
+     */
+    public function removeByCategory($category = null)
+    {
+        $providers = $this->getByCategory($category);
+        foreach ($providers as  $provider) {
+            if (isset($provider['module'])) {
+                $this->remove($provider['module']);
+            }
+        }
     }
 }

--- a/models/classes/runner/providers/ProviderRegistry.php
+++ b/models/classes/runner/providers/ProviderRegistry.php
@@ -54,14 +54,14 @@ class ProviderRegistry extends AbstractModuleRegistry
      */
     public function getByCategory($category = null)
     {
-        if (is_null($category)) {
+        if ( $category === null) {
             return [];
         }
 
         return array_filter(
             $this->getMap(),
             function($provider) use ($category) {
-                return isset($provider['category']) && $provider['category'] == $category;
+                return isset($provider['category']) && $provider['category'] === $category;
             }
         );
     }
@@ -73,7 +73,7 @@ class ProviderRegistry extends AbstractModuleRegistry
     public function removeByCategory($category = null)
     {
         $providers = $this->getByCategory($category);
-        foreach ($providers as  $provider) {
+        foreach ($providers as $provider) {
             if (isset($provider['module'])) {
                 $this->remove($provider['module']);
             }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -135,6 +135,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.8.0');
         }
 
-        $this->skip('7.8.0', '12.0.0');
+        $this->skip('7.8.0', '12.1.0');
     }
 }

--- a/test/unit/runner/providers/ProviderRegistryTest.php
+++ b/test/unit/runner/providers/ProviderRegistryTest.php
@@ -116,13 +116,13 @@ class ProviderRegistryTest extends TestCase
     }
 
     /**
-     * Test removoing providers from a category
+     * Test removing providers from a category
      */
     public function testRemoveByCategory()
     {
         $map = self::$map;
         $registry = $this->getMockBuilder(ProviderRegistry::class)
-                ->setMethods(['getMap', 'setConfig','remove'])
+                ->setMethods(['getMap', 'setConfig', 'remove'])
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -136,13 +136,13 @@ class ProviderRegistryTest extends TestCase
     }
 
     /**
-     * Test removoing providers from a wrong category
+     * Test removing providers from a wrong category
      */
     public function testRemoveByWrongCategory()
     {
         $map = self::$map;
         $registry = $this->getMockBuilder(ProviderRegistry::class)
-                ->setMethods(['getMap', 'setConfig','remove'])
+                ->setMethods(['getMap', 'setConfig', 'remove'])
                 ->disableOriginalConstructor()
                 ->getMock();
 

--- a/test/unit/runner/providers/ProviderRegistryTest.php
+++ b/test/unit/runner/providers/ProviderRegistryTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoTests\test\unit\runner\providers;
+
+use common_exception_InconsistentData;
+use oat\generis\test\TestCase;
+use oat\taoTests\models\runner\providers\ProviderRegistry;
+
+/**
+ * Test the ProviderRegistry
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class TestProviderTest extends TestCase
+{
+
+    private static $map = [
+        [
+            'id'          => 'qti',
+            'name'        => 'QTI runner',
+            'module'      => 'taoQtiTest/runner/provider/qti',
+            'bundle'      => 'taoQtiTest/loader/qtiTestRunner.min',
+            'description' => 'QTI implementation of the test runner',
+            'category'    => 'runner',
+            'active'      => true,
+            'tags'        => [ 'core', 'qti', 'runner' ]
+        ], [
+            'id'          => 'qtiprint',
+            'name'        => 'QTI runner for paper',
+            'module'      => 'taoQtiPrint/runner/provider/qtiprint',
+            'bundle'      => 'taoQtiPrint/loader/qtiTestRunner.min',
+            'description' => 'QTI implementation of the test runner on paper',
+            'category'    => 'runner',
+            'active'      => true,
+            'tags'        => [ 'core', 'qti', 'runner', 'print' ]
+        ], [
+            'id'       => 'request',
+            'name'     => 'request communicator',
+            'module'   => 'core/communicator/request',
+            'bundle'   => 'loader/vendor.min',
+            'category' => 'communicator',
+            'active'   => true,
+            'tags'     => [ ]
+        ], [
+            'id'       => 'sockets',
+            'name'     => 'web sockets communicator',
+            'module'   => 'core/communicator/ws',
+            'bundle'   => 'loader/vendor.min',
+            'category' => 'communicator',
+            'active'   => true,
+            'tags'     => [ ]
+        ], [
+            'id'       => 'poll',
+            'name'     => 'poll communicator',
+            'module'   => "core/communicator/poll",
+            'bundle'   => 'loader/vendor.min',
+            'category' => 'communicator',
+            'active'   => true,
+            'tags'     => [ ]
+        ], [
+            'id' => 'qtiServiceProxy',
+            'module' => 'taoQtiTest/runner/proxy/qtiServiceProxy',
+            'bundle' => 'taoQtiTest/loader/qtiTestRunner.min',
+            'category' => 'proxy',
+            'active'   => true,
+            'tags'     => [ ]
+        ]
+    ];
+
+    /**
+     * Data provider
+     * @return array the data
+     */
+    public function categoryFindingProvider()
+    {
+        return [
+            [ null, 0 ],
+            [ '', 0 ],
+            [ 'foo', 0 ],
+            [ 'runner', 2 ],
+            [ 'communicator', 3 ],
+            [ 'proxy', 1 ],
+        ];
+    }
+
+    /**
+     * Test getting providers by category
+     * @dataProvider categoryFindingProvider
+     */
+    public function testGetByCategory($category, $expectedProviderCount)
+    {
+        $registry = $this->getMockBuilder(ProviderRegistry::class)
+                ->setMethods(['getMap', '__construct'])
+                ->disableOriginalConstructor()
+                ->getMock();
+        $registry->method('getMap')->willReturn(self::$map);
+
+        $providers = $registry->getByCategory($category);
+        $this->assertEquals(count($providers), $expectedProviderCount);
+    }
+
+    /**
+     * Test removoing providers from a category
+     */
+    public function testRemoveByCategory()
+    {
+        $map = self::$map;
+        $registry = $this->getMockBuilder(ProviderRegistry::class)
+                ->setMethods(['getMap', '__construct','remove'])
+                ->disableOriginalConstructor()
+                ->getMock();
+        $registry->method('getMap')->willReturn($map);
+        $registry->expects($this->once())
+             ->method('remove')
+             ->with('taoQtiTest/runner/proxy/qtiServiceProxy');
+        $registry->removeByCategory('proxy');
+    }
+}

--- a/test/unit/runner/providers/ProviderRegistryTest.php
+++ b/test/unit/runner/providers/ProviderRegistryTest.php
@@ -19,7 +19,6 @@
 
 namespace oat\taoTests\test\unit\runner\providers;
 
-use common_exception_InconsistentData;
 use oat\generis\test\TestCase;
 use oat\taoTests\models\runner\providers\ProviderRegistry;
 
@@ -28,7 +27,7 @@ use oat\taoTests\models\runner\providers\ProviderRegistry;
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-class TestProviderTest extends TestCase
+class ProviderRegistryTest extends TestCase
 {
 
     private static $map = [
@@ -91,12 +90,12 @@ class TestProviderTest extends TestCase
     public function categoryFindingProvider()
     {
         return [
-            [ null, 0 ],
-            [ '', 0 ],
-            [ 'foo', 0 ],
-            [ 'runner', 2 ],
-            [ 'communicator', 3 ],
-            [ 'proxy', 1 ],
+            [ null, [] ],
+            [ '', [] ],
+            [ 'foo', [] ],
+            [ 'runner', [self::$map[0], self::$map[1]] ],
+            [ 'communicator', [self::$map[2], self::$map[3],self::$map[4]]  ],
+            [ 'proxy', [self::$map[5]] ],
         ];
     }
 
@@ -104,16 +103,16 @@ class TestProviderTest extends TestCase
      * Test getting providers by category
      * @dataProvider categoryFindingProvider
      */
-    public function testGetByCategory($category, $expectedProviderCount)
+    public function testGetByCategory($category, $expectedProviders)
     {
         $registry = $this->getMockBuilder(ProviderRegistry::class)
-                ->setMethods(['getMap', '__construct'])
+                ->setMethods(['getMap', 'setConfig'])
                 ->disableOriginalConstructor()
                 ->getMock();
         $registry->method('getMap')->willReturn(self::$map);
 
         $providers = $registry->getByCategory($category);
-        $this->assertEquals(count($providers), $expectedProviderCount);
+        $this->assertEquals(array_values($providers), $expectedProviders);
     }
 
     /**
@@ -123,13 +122,36 @@ class TestProviderTest extends TestCase
     {
         $map = self::$map;
         $registry = $this->getMockBuilder(ProviderRegistry::class)
-                ->setMethods(['getMap', '__construct','remove'])
+                ->setMethods(['getMap', 'setConfig','remove'])
                 ->disableOriginalConstructor()
                 ->getMock();
+
         $registry->method('getMap')->willReturn($map);
+
         $registry->expects($this->once())
              ->method('remove')
              ->with('taoQtiTest/runner/proxy/qtiServiceProxy');
+
         $registry->removeByCategory('proxy');
+    }
+
+    /**
+     * Test removoing providers from a wrong category
+     */
+    public function testRemoveByWrongCategory()
+    {
+        $map = self::$map;
+        $registry = $this->getMockBuilder(ProviderRegistry::class)
+                ->setMethods(['getMap', 'setConfig','remove'])
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $registry->method('getMap')->willReturn($map);
+
+        $registry->expects($this->never())
+             ->method('remove')
+             ->with($this->any());
+
+        $registry->removeByCategory('foo');
     }
 }


### PR DESCRIPTION
The goal is to use the provider registry for all providers : runner, communicator and proxy. 
But since the registry records entry by module name and we need to differentiate the type of provider, we will use the categories for that purpose.

This PR adds the abaility to get the providers from the registry by category and to remove all providers for a given category.

This PR can be tested  using PHP unit tests, from the TAO root : 
```
./vendor/bin/phpunit taoTests/test/unit/runner/providers/ProviderRegistryTest.php
```
```
./vendor/bin/phpunit taoTests/test/unit
```