### PR TITLE
Fix/nex 150 add missing fields to package json

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '13.0.0',
+    'version' => '13.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -145,6 +145,8 @@ class Updater extends \common_ext_ExtensionUpdater
             $clientLibRegistry = ClientLibRegistry::getRegistry();
             $clientLibRegistry->register('taoTests/runner', $taoTestRunnerDir);
             $this->setVersion('13.0.0');
-        }        
+        }
+
+        $this->skip('13.0.0', '13.0.1');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@oat-sa/tao-test",
   "version": "0.1.0",
-  "description": "",
+  "description": "Tao Test",
   "keywords": [],
-  "license": "GPL-2",
+  "license": "GPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oat-sa/extension-tao-test.git"
+  },
   "dependencies": {
     "@oat-sa/tao-test-runner": "^0.2.0"
   }


### PR DESCRIPTION
Add required fields, because NPM show some warn message if necessary fields are missing from `package.json`.