### PR TITLE
Deprecate test data

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '13.2.1',
+    'version' => '13.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -147,6 +147,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.0.0');
         }
 
-        $this->skip('13.0.0', '13.2.1');
+        $this->skip('13.0.0', '13.3.0');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@oat-sa/tao-test-runner": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.4.0.tgz",
-      "integrity": "sha512-/iFU1c4YKhqa8tKzagMFNjRhirtZyVi81MiMJTxzoULzwH7jBoITs/CRyqJuWl0ah8Z2HmjnjyBu2Qo6IY6WtQ=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
+      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "url": "https://github.com/oat-sa/extension-tao-test.git"
   },
   "dependencies": {
-    "@oat-sa/tao-test-runner": "0.4.0"
+    "@oat-sa/tao-test-runner": "github:oat-sa/tao-test-runner-fe#feature/NEX-238_deprecate-test-data"
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "url": "https://github.com/oat-sa/extension-tao-test.git"
   },
   "dependencies": {
-    "@oat-sa/tao-test-runner": "github:oat-sa/tao-test-runner-fe#feature/NEX-238_deprecate-test-data"
+    "@oat-sa/tao-test-runner": "^0.5.0"
   }
 }


### PR DESCRIPTION
 Related to https://oat-sa.atlassian.net/browse/NEX-238

Update to the last version of tao-test-runner-fe : 
 - Deprecate `testData` (but keep it to ensure backward compatibility)
 - Add new methods for the test runner API : 
   - `getConfig` returns the full test runner configuration
   - `getOptions` returns the configuration options (feature flags, platform/tenant config). Previously returned by `testData.config` and today under `config.options`
 - `getPluginsConfig` returns the plugins configuration. Previously returned by `testData.config.plugins` and today under `config.options.plugins
 - `getPluginConfig` the configuration of a given plugin (same as `this.getConfig` within a plugin)

Requires : 
 - [x] https://github.com/oat-sa/tao-test-runner-fe/pull/12

Todo : 
 - [x] change the branch to the release in `views/package.json` 
 - [x] udpate `views/package-lock.json` 