### PR TITLE
Feature/tdr 10 upgrade jquery

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,13 +31,13 @@ return array(
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '13.4.2',
+    'version' => '13.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.1.0',
         'taoItems' => '>=6.0.0',
         'taoBackOffice' => '>=3.0.0',
-        'tao' => '>=38.5.0'
+        'tao' => '>=39.7.0'
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAOTest.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -147,6 +147,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.0.0');
         }
 
-        $this->skip('13.0.0', '13.4.2');
+        $this->skip('13.0.0', '13.5.0');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -5,9 +5,8 @@
   "requires": true,
   "dependencies": {
     "@oat-sa/tao-test-runner": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.5.0.tgz",
-      "integrity": "sha512-TBUeLGRdqYChIDteImjTXcMYKOxTvho/hAuRMyFyBlTlpwNsGt1PFgTKevMP8g7MadHTcKXmPHK0unEanNHD0Q=="
+      "version": "github:oat-sa/tao-test-runner-fe#1829227f59f626de593c599ba19709afb02f9370",
+      "from": "github:oat-sa/tao-test-runner-fe#breaking/TDR-10_upgrade-jquery"
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -9,6 +9,6 @@
     "url": "https://github.com/oat-sa/extension-tao-test.git"
   },
   "dependencies": {
-    "@oat-sa/tao-test-runner": "^0.5.0"
+    "@oat-sa/tao-test-runner": "oat-sa/tao-test-runner-fe#breaking/TDR-10_upgrade-jquery"
   }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TDR-10

 - Update jquery from 1.9.1 to 2.2.4 (compatible)

Requires : 
 - [ ] https://github.com/oat-sa/tao-core-libs-fe/pull/13
 - [ ] https://github.com/oat-sa/tao-core-sdk-fe/pull/49
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/73
 - [ ] https://github.com/oat-sa/tao-test-runner-fe/pull/15
 - [ ] Update dependency to the package in `views/package.json` and ensure `views/package-lock.json` is updated

How to test : 
 -  Smoke/Regression testing