### PR TITLE
Feature/actp 422/timer adjustment

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '13.6.0',
+    'version' => '13.7.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/models/classes/runner/time/TimerAdjustmentMapInterface.php
+++ b/models/classes/runner/time/TimerAdjustmentMapInterface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\models\runner\time;
+
+
+/**
+ * Interface TimerAdjustmentMapInterface
+ *
+ * Describes an API for timer adjustment storage and access.
+ *
+ * @package oat\taoTests\models\classes\runner\time
+ */
+interface TimerAdjustmentMapInterface
+{
+    /**
+     * Puts an increase to the map
+     * @param string $sourceId
+     * @param int $seconds
+     * @return TimerAdjustmentMapInterface
+     */
+    public function increase(string $sourceId, int $seconds): TimerAdjustmentMapInterface;
+
+    /**
+     * Puts an decrease to the map
+     * @param string $sourceId
+     * @param int $seconds
+     * @return TimerAdjustmentMapInterface
+     */
+    public function decrease(string $sourceId, int $seconds): TimerAdjustmentMapInterface;
+
+    /**
+     * Gets the calculated adjustment in seconds
+     * @param string $sourceId
+     * @return int
+     */
+    public function get(string $sourceId): int;
+
+    /**
+     * Removes an entry specified by $sourceId
+     * @param string $sourceId
+     * @return TimerAdjustmentMapInterface
+     */
+    public function remove(string $sourceId): TimerAdjustmentMapInterface;
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -25,7 +25,6 @@ namespace oat\taoTests\scripts\update;
 use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoTests\models\runner\providers\TestProviderService;
 use oat\taoTests\scripts\install\RegisterTestPluginService;
-use oat\taoTests\scripts\install\RegisterTestRunnerFeatureService;
 use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
@@ -151,6 +150,7 @@ class Updater extends \common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('13.4.5');
         }
+
         $this->skip('13.4.5', '13.7.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -151,6 +151,6 @@ class Updater extends \common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('13.4.5');
         }
-        $this->skip('13.4.5', '13.6.0');
+        $this->skip('13.4.5', '13.7.0');
     }
 }


### PR DESCRIPTION
Timer adjustments are included when calculating maximum time limits and remaining time during the test session.
 
Related to : https://oat-sa.atlassian.net/browse/TCA-399
& https://oat-sa.atlassian.net/browse/TCA-422
 
`QtiTimeConstraint` maximum remaining time calculation is updated to include adjustments, minimum remaining time calculation is fixed to exclude `extraTime`. Values serialized and provided to FE updated. In order to make sure the consumed extra time calculation is correct the `endItemTimer` was updated. `taoQtiTest_helpers_TestSession::closeTimer()` makes sure that during timeout event the remaining time is 0, updated to include timer adjustments.
 
#### How to test
 
Manual testing can be performed in playground environment created for this feature or local environment with appropriate branches of `taoTests`, `taoQtiTest`, `taoProctoring`. The configuration option `DeliveryExecutionStateService::OPTION_TIME_HANDLING` should be set to `DeliveryExecutionStateService::TIME_HANDLING_TIMER_ADJUSTMENT`.

- As a test taker launch a proctored test with time limits
- As a proctor authorize the test to start, when the test is in progress pause it
- As a proctor refresh the delivery execution list
- As a proctor click on Change time button, specify how many minutes should be added/subtracted and click OK.
- As a proctor authorize the test session
- As a test taker Proceed to the test and see that the timer value is updated
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-proctoring/pull/801
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1352
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1750