### PR TITLE
Added adjustment type in timer adjustment map

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '13.7.0',
+    'version' => '14.0.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/models/classes/runner/time/TimerAdjustmentMapInterface.php
+++ b/models/classes/runner/time/TimerAdjustmentMapInterface.php
@@ -50,7 +50,7 @@ interface TimerAdjustmentMapInterface
     public function decrease(string $sourceId, string $type, int $seconds): TimerAdjustmentMapInterface;
 
     /**
-     * Gets the calculated adjustment in seconds
+     * Gets the calculated total adjustments of all types stored for provided source ID in seconds.
      * @param string $sourceId
      * @return int
      */

--- a/models/classes/runner/time/TimerAdjustmentMapInterface.php
+++ b/models/classes/runner/time/TimerAdjustmentMapInterface.php
@@ -57,6 +57,8 @@ interface TimerAdjustmentMapInterface
     public function get(string $sourceId): int;
 
     /**
+     * Gets the calculated adjustments for provided source ID and adjustment type in seconds.
+     *
      * @param string $sourceId
      * @param string $type
      * @return int

--- a/models/classes/runner/time/TimerAdjustmentMapInterface.php
+++ b/models/classes/runner/time/TimerAdjustmentMapInterface.php
@@ -34,18 +34,20 @@ interface TimerAdjustmentMapInterface
     /**
      * Puts an increase to the map
      * @param string $sourceId
+     * @param string $type
      * @param int $seconds
      * @return TimerAdjustmentMapInterface
      */
-    public function increase(string $sourceId, int $seconds): TimerAdjustmentMapInterface;
+    public function increase(string $sourceId, string $type, int $seconds): TimerAdjustmentMapInterface;
 
     /**
      * Puts an decrease to the map
      * @param string $sourceId
+     * @param string $type
      * @param int $seconds
      * @return TimerAdjustmentMapInterface
      */
-    public function decrease(string $sourceId, int $seconds): TimerAdjustmentMapInterface;
+    public function decrease(string $sourceId, string $type, int $seconds): TimerAdjustmentMapInterface;
 
     /**
      * Gets the calculated adjustment in seconds
@@ -55,9 +57,23 @@ interface TimerAdjustmentMapInterface
     public function get(string $sourceId): int;
 
     /**
+     * @param string $sourceId
+     * @param string $type
+     * @return int
+     */
+    public function getByType(string $sourceId, string $type): int;
+
+    /**
      * Removes an entry specified by $sourceId
      * @param string $sourceId
      * @return TimerAdjustmentMapInterface
      */
     public function remove(string $sourceId): TimerAdjustmentMapInterface;
+
+    /**
+     * @param string $sourceId
+     * @param string $type
+     * @return TimerAdjustmentMapInterface
+     */
+    public function removeForType(string $sourceId, string $type): TimerAdjustmentMapInterface;
 }

--- a/models/classes/runner/time/TimerAdjustmentMapInterface.php
+++ b/models/classes/runner/time/TimerAdjustmentMapInterface.php
@@ -62,18 +62,4 @@ interface TimerAdjustmentMapInterface
      * @return int
      */
     public function getByType(string $sourceId, string $type): int;
-
-    /**
-     * Removes an entry specified by $sourceId
-     * @param string $sourceId
-     * @return TimerAdjustmentMapInterface
-     */
-    public function remove(string $sourceId): TimerAdjustmentMapInterface;
-
-    /**
-     * @param string $sourceId
-     * @param string $type
-     * @return TimerAdjustmentMapInterface
-     */
-    public function removeForType(string $sourceId, string $type): TimerAdjustmentMapInterface;
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -151,6 +151,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('13.4.5');
         }
 
-        $this->skip('13.4.5', '13.7.0');
+        $this->skip('13.4.5', '14.0.0');
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TCA-607

Problem: 
For proctor screen we have to return list of all timers modifications (extended time, adjusted time, extra time). To be able to differentiate types of modification in timer adjustment map we have to store each modification's type.

Solution:
Store each modification in timer adjustment map under related type key. 
Add methods to get modification by type.