### PR TITLE
Disable preview for empty tests

### DIFF
--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -79,6 +79,12 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
     public function editTest()
     {
         $test = new core_kernel_classes_Resource($this->getRequestParameter('id'));
+
+        $this->setData(
+            'isPreviewEnabled',
+            $this->service->hasItems($test) ? true : false
+        );
+
         if (!$this->isLocked($test)) {
             // my lock
             $lock = LockManager::getImplementation()->getLockData($test);

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -80,10 +80,7 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
     {
         $test = new core_kernel_classes_Resource($this->getRequestParameter('id'));
 
-        $this->setData(
-            'isPreviewEnabled',
-            $this->service->hasItems($test) ? true : false
-        );
+        $this->setData('isPreviewEnabled', $this->service->hasItems($test));
 
         if (!$this->isLocked($test)) {
             // my lock

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '14.3.0',
+    'version' => '14.4.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/views/js/controller/tests/editTest.js
+++ b/views/js/controller/tests/editTest.js
@@ -22,16 +22,26 @@
  */
 define([
     'jquery',
-    'ui/lock'
-],	function($, lock){
+    'ui/lock',
+    'module',
+    'layout/actions',
+],	function($, lock, module, actions){
     'use strict';
 
     return {
+
 
         /**
          * Controller's entrypoint
          */
         start(){
+
+            const config = module.config();
+            const previewAction = actions.getBy('test-preview')
+            if (previewAction) {
+                previewAction.state.disabled = !config.isPreviewEnabled;
+            }
+
             $('#lock-box').each(function() {
                 lock($(this)).register();
             });

--- a/views/templates/Tests/editTest.tpl
+++ b/views/templates/Tests/editTest.tpl
@@ -19,3 +19,13 @@ use oat\tao\helpers\Template;
 </div>
 
 <?php Template::inc('footer.tpl', 'tao'); ?>
+
+<script type="text/javascript">
+    requirejs.config({
+        config: {
+            'taoTests/controller/tests/editTest' : {
+                'isPreviewEnabled' : <?= json_encode(get_data('isPreviewEnabled')) ?>
+            }
+        }
+    });
+</script>


### PR DESCRIPTION
Added a flag that defines wether or not a tests can be previewed. This is currently only influenced by wether or not the test has items.