### PR TITLE
Feature/NEX-1529/remove test preview dependency

### DIFF
--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -18,19 +18,20 @@
  */
 define([
     'lodash',
+    'i18n',
     'layout/actions/binder',
     'uri',
     'ui/feedback',
     'core/logger',
     'taoTests/previewer/factory'
-], function(_, binder, uri, feedback, loggerFactory, previewerFactory){
+], function(_, __, binder, uri, feedback, loggerFactory, previewerFactory){
     'use strict';
 
     const logger = loggerFactory('taoTests/controller/action');
 
     binder.register('testPreview', function testPreview(actionContext) {
         previewerFactory(
-            'qtiTest',
+            'qtiTest', // TODO - move to BE configuration
             uri.decode(actionContext.uri),
             {
                 readOnly: false,
@@ -38,7 +39,7 @@ define([
             })
             .catch(err => {
                 logger.error(err);
-                feedback().error('Test Preview is not installed, please contact to your administrator.');
+                feedback().error(__('Test Preview is not installed, please contact to your administrator.'));
             });
     });
 });

--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -32,11 +32,11 @@ define([
     let previewerFactory = null;
     providerLoaderFactory()
         .addList({
-            previwers: {
+            previewers: {
                 id: 'qtiTests',
                 module: 'taoQtiTestPreviewer/previewer/adapter/test/qtiTest',
                 bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
-                category: 'previwers'
+                category: 'previewers'
             }
         })
         .load(context.bundle)

--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -55,7 +55,7 @@ define([
                 fullPage: true
             });
         } else {
-            feedback().error('Test Preview is not installed, please contact to your administrator.');
+            feedback().error('Test Preview is not installed, please contact your administrator.');
         }
     });
 

--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -18,45 +18,27 @@
  */
 define([
     'lodash',
-    'context',
     'layout/actions/binder',
-    'core/providerLoader',
     'uri',
     'ui/feedback',
-    'core/logger'
-], function(_, context, binder, providerLoaderFactory, uri, feedback, loggerFactory){
+    'core/logger',
+    'taoTests/previewer/factory'
+], function(_, binder, uri, feedback, loggerFactory, previewerFactory){
     'use strict';
 
     const logger = loggerFactory('taoTests/controller/action');
 
-    let previewerFactory = null;
-    providerLoaderFactory()
-        .addList({
-            previewers: {
-                id: 'qtiTests',
-                module: 'taoQtiTestPreviewer/previewer/adapter/test/qtiTest',
-                bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
-                category: 'previewers'
-            }
-        })
-        .load(context.bundle)
-        .then(function (providers) {
-            previewerFactory = providers[0];
-        })
-        .catch(err => {
-            logger.error(err);
-        });
-
-
     binder.register('testPreview', function testPreview(actionContext) {
-        if (previewerFactory) {
-            previewerFactory.init(uri.decode(actionContext.uri), {
+        previewerFactory(
+            'qtiTest',
+            uri.decode(actionContext.uri),
+            {
                 readOnly: false,
                 fullPage: true
+            })
+            .catch(err => {
+                logger.error(err);
+                feedback().error('Test Preview is not installed, please contact to your administrator.');
             });
-        } else {
-            feedback().error('Test Preview is not installed, please contact your administrator.');
-        }
     });
-
 });

--- a/views/js/previewer/factory.js
+++ b/views/js/previewer/factory.js
@@ -1,0 +1,71 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Hanna Dzmitryieva <hanna@taotesting.com>
+ */
+define([
+    'lodash',
+    'context',
+    'module',
+    'core/providerLoader',
+    'core/providerRegistry',
+    'core/logger'
+], function (
+    _,
+    context,
+    module,
+    providerLoaderFactory,
+    providerRegistry
+) {
+    'use strict';
+
+    /**
+     * Loads and display the test previewer
+     * @param {String} type - The type of previewer
+     * @param {String} uri - The URI of the test to load
+     * @param {Object} [config] - Some config entries
+     * @param {String} [config.fullPage] - Force the previewer to occupy the full window.
+     * @param {String} [config.readOnly] - Do not allow to modify the previewed test.
+     * @param {Object} [config.previewers] - Optionally load static adapters. By default take them from the module's config.
+     * @returns {Promise}
+     */
+    function previewerFactory(type, uri, config) {
+        config = _.defaults(config || {}, module.config());
+        return providerLoaderFactory()
+            .addList(config.previewers)
+            .load(context.bundle)
+            .then(function (providers) {
+                _.forEach(providers, function (provider) {
+                    previewerFactory.registerProvider(provider.name, provider);
+                });
+            })
+            .then(function () {
+                return previewerFactory.getProvider(type);
+            })
+            .then(function (provider) {
+                return provider.init(uri, config);
+            });
+    }
+
+    return providerRegistry(previewerFactory, function validateProvider(provider) {
+        if (!_.isFunction(provider.init)) {
+            throw new TypeError('The previewer provider MUST have a init() method');
+        }
+        return true;
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-1529
Related to:
https://github.com/oat-sa/extension-tao-testqti/pull/1904
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/88

**Issue:**
In working branches 
"oat-sa/extension-tao-test": "dev-feature/NEX-1043/test-preview-base-branch",  
"oat-sa/extension-tao-testqti": "dev-feature/NEX-1043/test-preview-base-branch", 
an issue with building bundles because of new dependency taoQtiTestPreview

**Solution:**
Dynamically load taoQtiTestPreviewer adapter

**How to test:**

1. checkout brances "oat-sa/extension-tao-test": "dev-feature/NEX-1043/test-preview-base-branch",  "oat-sa/extension-tao-testqti": "dev-feature/NEX-1043/test-preview-base-branch", 
2. in taoQtiTestPreviwer checkout to develop
3. open Tests page
4. press Preview button
5. in taoQtiTestPreviwer checkout to feature/NEX-1043/test-preview-base-branch
6. reload Tests page
7. press Preview button