### PR TITLE
Fix broken unit tests

### DIFF
--- a/test/unit/runner/plugins/TestPluginServiceTest.php
+++ b/test/unit/runner/plugins/TestPluginServiceTest.php
@@ -63,6 +63,14 @@ class TestPluginServiceTest extends TestCase
         ];
 
     /**
+     * @before
+     */
+    public function init(): void
+    {
+        define('CONFIG_PATH', '/');
+    }
+
+    /**
      * Get the service with the stubbed registry
      * @return TestPluginService
      */
@@ -81,7 +89,8 @@ class TestPluginServiceTest extends TestCase
     }
 
     /**
-     * Check the service is a service
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testApi()
     {
@@ -91,7 +100,8 @@ class TestPluginServiceTest extends TestCase
     }
 
     /**
-     * Test the method TestPluginService::getAllPlugins
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testGetAllPlugins()
     {
@@ -121,7 +131,8 @@ class TestPluginServiceTest extends TestCase
     }
 
     /**
-     * Test the method TestPluginService::getPlugin
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testGetOnePlugin()
     {

--- a/test/unit/runner/providers/TestProviderServiceTest.php
+++ b/test/unit/runner/providers/TestProviderServiceTest.php
@@ -62,6 +62,14 @@ class TestProviderServiceTest extends TestCase
     ];
 
     /**
+     * @before
+     */
+    public function init(): void
+    {
+        define('CONFIG_PATH', '/');
+    }
+
+    /**
      * Get the service with the stubbed registry
      * @return TestProviderService
      */
@@ -80,7 +88,8 @@ class TestProviderServiceTest extends TestCase
     }
 
     /**
-     * Check the service is a service
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testApi()
     {
@@ -90,7 +99,8 @@ class TestProviderServiceTest extends TestCase
     }
 
     /**
-     * Test the method TestProviderService::getAllProviders
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testGetAllProviders()
     {
@@ -117,7 +127,8 @@ class TestProviderServiceTest extends TestCase
     }
 
     /**
-     * Test the method TestProviderService::getProvider
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testGetOneProvider()
     {


### PR DESCRIPTION
The [same approach](https://github.com/oat-sa/tao-core/pull/2661) from `tao-core` has been implemented here as well to unlock CI pipeline again.