### PR TITLE
Remove direct require of composer-npm-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/composer-npm-bridge": "^0.3.0"
+        "oat-sa/composer-npm-bridge": "^0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,7 @@
         }
     },
     "require": {
-        "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/composer-npm-bridge": "^0.4.0"
+        "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return [
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '14.6.0',
+    'version' => '14.6.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.3.0',


### PR DESCRIPTION
Work under [CGF-22](https://oat-sa.atlassian.net/browse/CGF-22)

It is needed to avoid issues with updating to the new version. 
`composer-npm-bridge` properly required in the `tao-core`.