### PR TITLE
Fix [CON-203] - Color of arrowheads does not match with color of lines

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return [
     'label' => 'Test core extension',
     'description' => 'TAO Tests extension contains the abstraction of the test-runners, but requires an implementation in order to be able to run tests',
     'license' => 'GPL-2.0',
-    'version' => '14.6.1',
+    'version' => '14.6.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.3.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@oat-sa/tao-test",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@oat-sa/tao-item-runner": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.6.1.tgz",
-      "integrity": "sha512-+7l2uG0+6idJoxUZTojRLmZQvMgC0Z5BpIoWfbvgdM2Z/TiPHFk8PoLfn7VAOfkHl0CFTmgjHDI8N6Up5s0DGg=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.7.1.tgz",
+      "integrity": "sha512-3+kd6sH5yckD9iH3+IDnmTHctT0dFUx55vFfhlo8LvzyaE77I6Eci0uyOQpoDUMqRTzyw7tABBkNue0WkfAAsw=="
     },
     "@oat-sa/tao-test-runner": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.0.tgz",
-      "integrity": "sha512-285Egik8KVlcJu9XJNYUEwEdQtQQYT5bXOVhcJAwnvyEiUbkiUZE0gNrg81LUZo+qpeaOmtzplHRhk3jxKyJWg=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-test-runner/-/tao-test-runner-0.8.1.tgz",
+      "integrity": "sha512-SNSJzlhOhog43wdWUaOYPJICnOfq+Gdwd7ES6z+7AF/0Y79GY7nuK77ZZiglS+BR6a8LnkhPo5vHz+f2SUdNqg=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-test",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tao Test",
   "keywords": [],
   "license": "GPL-2.0",
@@ -9,7 +9,7 @@
     "url": "https://github.com/oat-sa/extension-tao-test.git"
   },
   "dependencies": {
-    "@oat-sa/tao-item-runner": "^0.6.1",
-    "@oat-sa/tao-test-runner": "^0.8.0"
+    "@oat-sa/tao-item-runner": "^0.7.1",
+    "@oat-sa/tao-test-runner": "^0.8.1"
   }
 }


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-203

**Related work**

https://github.com/oat-sa/extension-tao-itemqti/issues/1577

**Description**

The color of all arrowheads (including axis arrowheads) changes, when we change the current line or add new. So, it will always inherit the color from the last path created with the arrow-end/ arrow-start attribute set.
 
![imagen](https://user-images.githubusercontent.com/34692207/104584984-aed6dd00-5663-11eb-9173-732e4fc5c82c.png)

The full description of [issue](https://github.com/oat-sa/extension-tao-itemqti)/issues/1577

Also, it looks like the PCI settings are broken on the construct side. When trying to open Lines options an error pops up in the console.

![imagen](https://user-images.githubusercontent.com/34692207/104585059-ca41e800-5663-11eb-939c-19309c432365.png)

**AC**

- [x] Fix arrow head color
- [ ] Fix error in console of PCI settings