### PR TITLE
fix: enable user to move class with tests

### DIFF
--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -216,7 +216,7 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
     /**
      * overwrite the parent moveAllInstances to add the requiresRight only in Items
      * @see tao_actions_TaoModule::moveResource()
-     * @requiresRight uri WRITE
+     * @requiresRight classUri WRITE
      */
     public function moveResource()
     {


### PR DESCRIPTION
This change will enable `move to` action on classes containing test resources.

https://oat-sa.atlassian.net/browse/AUT-198