### PR TITLE
fix: double move-to when dacSimple disabled

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -57,7 +57,7 @@
                     <action id="test-copy-to" name="Copy To" url="/taoTests/Tests/copyInstance" context="instance" group="tree" binding="copyTo">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="test-move-to" name="Move To" url="/taoTests/Tests/moveResource" context="resource" group="tree" binding="moveTo">
+                    <action id="test-move-to" name="Move To" url="/taoTests/Tests/moveResource" context="instance" group="tree" binding="moveTo">
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="class-move-to" name="Move To" url="/taoTests/Tests/moveClass" context="class" group="tree" binding="moveTo">


### PR DESCRIPTION
When taoDacSimple is enabled move to button displays twice.

https://oat-sa.atlassian.net/browse/AUT-1008