### PR TITLE
AUT-1034 move requestTimeout to cypress.json configs

### DIFF
--- a/views/cypress/tests/test.spec.js
+++ b/views/cypress/tests/test.spec.js
@@ -32,11 +32,11 @@ describe('Tests', () => {
         cy.intercept('GET', `**/${ selectors.treeRenderUrl }/getOntologyData**`).as('treeRender');
         cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
         cy.visit(urls.tests);
-        cy.wait('@treeRender', { requestTimeout: 10000 });
+        cy.wait('@treeRender');
         cy.get(`${selectors.root} a`)
             .first()
             .click();
-        cy.wait('@editClassLabel', { requestTimeout: 10000 });
+        cy.wait('@editClassLabel');
     });
 
     /**
@@ -79,11 +79,11 @@ describe('Tests', () => {
 
             cy.getSettled(`${selectors.root} a:nth(0)`)
             .click()
-            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .wait('@editClassLabel')
             .addClass(selectors.testClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.testClassForm, classMovedName);
 
-            cy.wait('@treeRender', { requestTimeout: 10000 });
+            cy.wait('@treeRender');
 
             cy.moveClassFromRoot(
                 selectors.root,
@@ -111,11 +111,11 @@ describe('Tests', () => {
 
             cy.getSettled(`${selectors.root} a:nth(0)`)
             .click()
-            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .wait('@editClassLabel')
             .addClass(selectors.testClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.testClassForm, className);
 
-            cy.wait('@editClassLabel', { requestTimeout: 10000 });
+            cy.wait('@editClassLabel');
 
             cy.deleteClassFromRoot(
                 selectors.root,

--- a/views/cypress/tests/tests-page.spec.js
+++ b/views/cypress/tests/tests-page.spec.js
@@ -26,9 +26,7 @@ describe('Tests Page', () => {
         cy.loginAsAdmin();
         cy.intercept('POST', '**/edit*').as('edit');
         cy.visit(urls.tests);
-        cy.wait('@edit', {
-            requestTimeout: 10000
-        });
+        cy.wait('@edit');
     });
 
     describe('tests page', () => {

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,7 +1,7 @@
 export default {
     deleteTest: '[data-context="resource"][data-action="removeNode"]',
     deleteClass: '[data-context="resource"][data-action="removeNode"]',
-    moveClass: '[id="test-move-to"][data-context="resource"][data-action="moveTo"]',
+    moveClass: '[id="class-move-to"][data-context="class"][data-action="moveTo"]',
     moveConfirmSelector: 'button[data-control="ok"]',
     addTest: '[data-context="resource"][data-action="instanciate"]',
     testForm: 'form[action="/taoTests/Tests/editTest"]',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1034

We have explicitly defined a specific time for most of our request interception/waiting. 
i.e: .wait('@editItem', { requestTimeout: 10000 }) 

We should make this requestTimeout of 10000ms the norm by defining it as a default in cypress.json and removing each explicit mention of it in our .wait() function calls.

**How to test:**
Run cypress and check that updated tests pass without errors after updating default request timeout.