### PR TITLE
fix/AUT-963/ e2e move treeRender in commands

### DIFF
--- a/views/cypress/tests/test.spec.js
+++ b/views/cypress/tests/test.spec.js
@@ -83,8 +83,6 @@ describe('Tests', () => {
             .addClass(selectors.testClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.testClassForm, classMovedName);
 
-            cy.wait('@treeRender');
-
             cy.moveClassFromRoot(
                 selectors.root,
                 selectors.moveClass,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-963
Dependency:

- [x] https://github.com/oat-sa/tao-core/pull/3124

Move wait.("@treeRender") to commands

How to test:
run test `taoTests/views/cypress/tests/test.spec.js`
