### PR TITLE
fix: stibilize e2e tests

### DIFF
--- a/views/cypress/tests/test.spec.js
+++ b/views/cypress/tests/test.spec.js
@@ -130,8 +130,6 @@ describe('Tests', () => {
             .addClass(selectors.testClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.testClassForm, className);
 
-            cy.wait('@editClassLabel');
-
             cy.deleteClassFromRoot(
                 selectors.root,
                 selectors.testClassForm,

--- a/views/cypress/tests/test.spec.js
+++ b/views/cypress/tests/test.spec.js
@@ -18,10 +18,11 @@
 
 import urls from '../utils/urls';
 import selectors from '../utils/selectors';
+import { getRandomNumber } from '../../../../tao/views/cypress/utils/helpers';
 
 describe('Tests', () => {
-    const className = 'Test E2E class';
-    const classMovedName = 'Test E2E class Moved';
+    const className = `Test E2E class ${getRandomNumber()}`;
+    const classMovedName = `Test E2E class Moved  ${getRandomNumber()}`;
     const newPropertyName = 'I am a new property in testing, hi!';
     const newPropertyAlias = 'testing_property_alias';
     const options = {
@@ -104,7 +105,7 @@ describe('Tests', () => {
                 selectors.moveConfirmSelector,
                 className,
                 classMovedName,
-                selectors.restResourceGetAll,
+                selectors.resourceGetAllUrl,
             );
         });
 

--- a/views/cypress/tests/test.spec.js
+++ b/views/cypress/tests/test.spec.js
@@ -117,6 +117,7 @@ describe('Tests', () => {
                 selectors.deleteConfirm,
                 classMovedName,
                 selectors.deleteTestUrl,
+                false
             );
         });
 

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -17,7 +17,7 @@ export default {
     moveClass: '[id="class-move-to"][data-context="class"][data-action="moveTo"]',
     moveConfirmSelector: 'button[data-control="ok"]',
 
-    restResourceGetAll: 'tao/RestResource/getAll',
+    resourceGetAllUrl: 'tao/RestResource/getAll',
     root: '[data-uri="http://www.tao.lu/Ontologies/TAOTest.rdf#Test"]',
 
     testForm: 'form[action="/taoTests/Tests/editTest"]',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1169
Depends https://github.com/oat-sa/tao-core/pull/3230

Stabilised old tests

How to test:
1. remove temporary delivery tests `ltiDeliveryProvider/views/cypress` `taoQtiTest/views/cypress/test/delivery` or exclude them
2. `cd tao/views`
3. `npm run cy:run`