### PR TITLE
Feature/tr 4339/custom theme in previewer from ClientConfig

### DIFF
--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -31,13 +31,16 @@ define([
     const logger = loggerFactory('taoTests/controller/action');
 
     binder.register('testPreview', function testPreview(actionContext) {
-        previewerFactory(
-            module.config().provider,
+        const config = module.config();
+        const previewerConfig = _.omit({
+            readOnly: false,
+            fullPage: true,
+            pluginsOptions: config.pluginsOptions
+        }, _.isUndefined);
+
+        previewerFactory(config.provider,
             uri.decode(actionContext.uri),
-            {
-                readOnly: false,
-                fullPage: true
-            })
+            previewerConfig)
             .catch(err => {
                 logger.error(err);
                 feedback().error(__('Test Preview is not installed, please contact to your administrator.'));


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4339

Base composer: see TAE branch in PR: https://oat-sa.atlassian.net/browse/TR-4339?focusedCommentId=191355

Migration from customer extension PR will add to `tao-enterprise-nfer-enot\config\tao\client_lib_config_registry.conf.php`:
```
...
return new oat\oatbox\config\ConfigurationService(array(
    'config' => array(
        ....
         'taoTests/previewer/factory' => array(
            ...
        ),
        'taoTests/controller/tests/action' => array(
            ....
            'pluginsOptions' =>  array(
                'itemThemeSwitcher' => array(
                    'activeNamespace' => 'nferEnotThemeEnotMaths'
                )
            )
        ),      
        ...  
    )
));

```
