### PR TITLE
fix: define test resource type in test edit form

### DIFF
--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:disable Generic.Files.LineLength
 /*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,6 +21,7 @@
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  *
  */
+// phpcs:enable
 
 use oat\oatbox\event\EventManager;
 use oat\tao\model\lock\LockManager;
@@ -47,9 +49,9 @@ use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
  * @license GPLv2  http://www.opensource.org/licenses/gpl-2.0.php
  *
  */
+// phpcs:ignore
 class taoTests_actions_Tests extends tao_actions_SaSModule
 {
-
     /**
      * @return EventManager
      */

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -25,6 +25,7 @@ use oat\oatbox\event\EventManager;
 use oat\tao\model\lock\LockManager;
 use oat\oatbox\validator\ValidatorInterface;
 use oat\tao\model\resources\ResourceWatcher;
+use oat\tao\model\TaoOntology;
 use oat\taoTests\models\event\TestUpdatedEvent;
 use oat\tao\model\controller\SignedFormInstance;
 use oat\tao\model\resources\Service\ClassDeleter;
@@ -114,6 +115,11 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
                 ]
             );
             $myForm = $formContainer->getForm();
+
+            $myForm->setOptions([
+                'resourceType' => TaoOntology::CLASS_URI_TEST
+            ]);
+
             if ($myForm->isSubmited() && $myForm->isValid()) {
                 $this->validateInstanceRoot($test->getUri());
 


### PR DESCRIPTION
Related to https://github.com/oat-sa/extension-tao-resource-workflow/pull/42

Define Test resourceType in form options

How to reproduce:

- Ensure your instance has taoResourceWorkflow installed
- Create item with content
- Export Item
- Open another environment with taoResourceWorkflow installed
- Import item
- Ensure the item has initially stated and defined in the workflow