### PR TITLE
feat: adding copy tests logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,10 +62,10 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
+        "oat-sa/generis": ">=15.24",
+        "oat-sa/tao-core": ">=52.1",
         "oat-sa/extension-tao-backoffice": ">=6.0.0",
-        "oat-sa/extension-tao-item": "dev-feat/RFE-530/integration-branch as 12.0"
+        "oat-sa/extension-tao-item": ">=11.33"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -63,9 +63,9 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.24.6",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0",
-        "oat-sa/extension-tao-item": ">=11.0.0"
+        "oat-sa/extension-tao-item": "dev-feat/RFE-530/integration-branch as 12.0"
     },
     "autoload": {
         "psr-4": {

--- a/manifest.php
+++ b/manifest.php
@@ -27,6 +27,7 @@
  */
 
 use oat\tao\model\user\TaoRoles;
+use oat\taoTests\models\Copier\CopierServiceProvider;
 use oat\taoTests\scripts\update\Updater;
 use oat\taoTests\scripts\install\SetupProvider;
 use oat\taoTests\scripts\install\RegisterFrontendPaths;
@@ -84,5 +85,8 @@ return [
 
         #BASE URL (usually the domain root)
         'BASE_URL' => ROOT_URL . 'taoTests/',
+    ],
+    'containerServiceProviders' => [
+        CopierServiceProvider::class,
     ],
 ];

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\taoTests\models\Copier;
 
 use oat\generis\model\data\Ontology;
+use oat\generis\model\OntologyRdf;
 use oat\tao\model\resources\Service\InstanceCopierProxy;
 use oat\tao\model\TaoOntology;
 use oat\oatbox\event\EventManager;
@@ -33,7 +34,6 @@ use oat\tao\model\resources\Service\ClassMetadataCopier;
 use oat\tao\model\resources\Service\ClassMetadataMapper;
 use oat\tao\model\resources\Service\InstanceMetadataCopier;
 use oat\tao\model\resources\Service\RootClassesListService;
-use oat\generis\model\fileReference\FileReferenceSerializer;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use taoTests_models_classes_TestsService;
@@ -57,6 +57,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
                 'addPropertyUriToBlacklist',
                 [
                     taoTests_models_classes_TestsService::PROPERTY_TEST_CONTENT,
+                    OntologyRdf::RDF_TYPE,
                 ]
             );
 
@@ -64,7 +65,6 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->set(TestContentCopier::class, TestContentCopier::class)
             ->args(
                 [
-                    service(FileReferenceSerializer::SERVICE_ID),
                     service(taoTests_models_classes_TestsService::class),
                     service(EventManager::SERVICE_ID),
                 ]

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -90,7 +90,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->call(
                 'withPermissionCopiers',
                 [
-                    tagged_iterator('tao.copier.permissions.instance.tests'),
+                    tagged_iterator('tao.copier.permissions'),
                 ]
             );
 
@@ -109,7 +109,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->call(
                 'withPermissionCopiers',
                 [
-                    tagged_iterator('tao.copier.permissions.class.tests'),
+                    tagged_iterator('tao.copier.permissions'),
                 ]
             );
 

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -24,6 +24,7 @@ namespace oat\taoTests\models\Copier;
 
 use oat\generis\model\data\Ontology;
 use oat\generis\model\OntologyRdf;
+use oat\generis\model\OntologyRdfs;
 use oat\tao\model\resources\Service\InstanceCopierProxy;
 use oat\tao\model\TaoOntology;
 use oat\oatbox\event\EventManager;
@@ -54,10 +55,12 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
         $services
             ->get(InstanceMetadataCopier::class)
             ->call(
-                'addPropertyUriToBlacklist',
+                'addPropertyUrisToBlacklist',
                 [
-                    taoTests_models_classes_TestsService::PROPERTY_TEST_CONTENT,
-                    OntologyRdf::RDF_TYPE,
+                    [
+                        taoTests_models_classes_TestsService::PROPERTY_TEST_CONTENT,
+                        OntologyRdfs::RDFS_LABEL,
+                    ]
                 ]
             );
 

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\models\Copier;
+
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Service\InstanceCopierProxy;
+use oat\tao\model\TaoOntology;
+use oat\oatbox\event\EventManager;
+use oat\tao\model\resources\Service\ClassCopier;
+use oat\tao\model\resources\Service\InstanceCopier;
+use oat\tao\model\resources\Service\ClassCopierProxy;
+use oat\tao\model\resources\Service\ClassMetadataCopier;
+use oat\tao\model\resources\Service\ClassMetadataMapper;
+use oat\tao\model\resources\Service\InstanceMetadataCopier;
+use oat\tao\model\resources\Service\RootClassesListService;
+use oat\generis\model\fileReference\FileReferenceSerializer;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use taoTests_models_classes_TestsService;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+class CopierServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(taoTests_models_classes_TestsService::class, taoTests_models_classes_TestsService::class)
+            ->factory(taoTests_models_classes_TestsService::class . '::singleton');
+
+        $services
+            ->get(InstanceMetadataCopier::class)
+            ->call(
+                'addPropertyUriToBlacklist',
+                [
+                    taoTests_models_classes_TestsService::PROPERTY_TEST_CONTENT,
+                ]
+            );
+
+        $services
+            ->set(TestContentCopier::class, TestContentCopier::class)
+            ->args(
+                [
+                    service(FileReferenceSerializer::SERVICE_ID),
+                    service(taoTests_models_classes_TestsService::class),
+                    service(EventManager::SERVICE_ID),
+                ]
+            );
+
+        $services
+            ->set(InstanceCopier::class . '::TESTS', InstanceCopier::class)
+            ->args(
+                [
+                    service(InstanceMetadataCopier::class),
+                    service(Ontology::SERVICE_ID)
+                ]
+            )
+            ->call(
+                'withInstanceContentCopier',
+                [
+                    service(TestContentCopier::class),
+                ]
+            )
+            ->call(
+                'withPermissionCopiers',
+                [
+                    tagged_iterator('tao.copier.permissions.instance.tests'),
+                ]
+            );
+
+        $services
+            ->set(ClassCopier::class . '::TESTS', ClassCopier::class)
+            ->share(false)
+            ->args(
+                [
+                    service(RootClassesListService::class),
+                    service(ClassMetadataCopier::class),
+                    service(InstanceCopier::class . '::TESTS'),
+                    service(ClassMetadataMapper::class),
+                    service(Ontology::SERVICE_ID),
+                ]
+            )
+            ->call(
+                'withPermissionCopiers',
+                [
+                    tagged_iterator('tao.copier.permissions.class.tests'),
+                ]
+            );
+
+        $services
+            ->set(TestClassCopier::class, TestClassCopier::class)
+            ->share(false)
+            ->args(
+                [
+                    service(ClassCopier::class . '::TESTS'),
+                    service(Ontology::SERVICE_ID),
+                ]
+            );
+
+        $services
+            ->get(ClassCopierProxy::class)
+            ->call(
+                'addClassCopier',
+                [
+                    TaoOntology::CLASS_URI_TEST,
+                    service(TestClassCopier::class),
+                ]
+            );
+
+        $services
+            ->get(InstanceCopierProxy::class)
+            ->call(
+                'addInstanceCopier',
+                [
+                    TaoOntology::CLASS_URI_TEST,
+                    service(InstanceCopier::class . '::TESTS'),
+                ]
+            );
+    }
+}

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -42,6 +42,9 @@ use taoTests_models_classes_TestsService;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
+/**
+ * @codeCoverageIgnore
+ */
 class CopierServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void

--- a/models/classes/Copier/TestClassCopier.php
+++ b/models/classes/Copier/TestClassCopier.php
@@ -33,11 +33,10 @@ use oat\tao\model\resources\Contract\ClassCopierInterface;
 
 class TestClassCopier implements ClassCopierInterface, ResourceTransferInterface
 {
-    /** @var ClassCopierInterface|ResourceTransferInterface */
-    private $taoClassCopier;
+    private ResourceTransferInterface $taoClassCopier;
     private Ontology $ontology;
 
-    public function __construct(ClassCopierInterface $taoClassCopier, Ontology $ontology)
+    public function __construct(ResourceTransferInterface $taoClassCopier, Ontology $ontology)
     {
         $this->taoClassCopier = $taoClassCopier;
         $this->ontology = $ontology;
@@ -47,9 +46,16 @@ class TestClassCopier implements ClassCopierInterface, ResourceTransferInterface
         core_kernel_classes_Class $class,
         core_kernel_classes_Class $destinationClass
     ): core_kernel_classes_Class {
-        $this->assertRootClass($class);
+        $result = $this->transfer(
+            new ResourceTransferCommand(
+                $class->getUri(),
+                $destinationClass->getUri(),
+                ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+                ResourceTransferCommand::TRANSFER_MODE_COPY,
+            )
+        );
 
-        return $this->taoClassCopier->copy($class, $destinationClass);
+        return $this->ontology->getClass($result->getDestination());
     }
 
     public function transfer(ResourceTransferCommand $command): ResourceTransferResult

--- a/models/classes/Copier/TestClassCopier.php
+++ b/models/classes/Copier/TestClassCopier.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\models\Copier;
+
+use InvalidArgumentException;
+use core_kernel_classes_Class;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
+use oat\tao\model\resources\Contract\ResourceTransferInterface;
+use oat\tao\model\resources\ResourceTransferResult;
+use oat\tao\model\TaoOntology;
+use oat\tao\model\resources\Contract\ClassCopierInterface;
+
+class TestClassCopier implements ClassCopierInterface, ResourceTransferInterface
+{
+    /** @var ClassCopierInterface|ResourceTransferInterface */
+    private $taoClassCopier;
+    private Ontology $ontology;
+
+    public function __construct(ClassCopierInterface $taoClassCopier, Ontology $ontology)
+    {
+        $this->taoClassCopier = $taoClassCopier;
+        $this->ontology = $ontology;
+    }
+
+    public function copy(
+        core_kernel_classes_Class $class,
+        core_kernel_classes_Class $destinationClass
+    ): core_kernel_classes_Class {
+        $this->assertRootClass($class);
+
+        return $this->taoClassCopier->copy($class, $destinationClass);
+    }
+
+    public function transfer(ResourceTransferCommand $command): ResourceTransferResult
+    {
+        $this->assertRootClass($this->ontology->getClass($command->getFrom()));
+
+        return $this->taoClassCopier->transfer($command);
+    }
+
+    private function assertRootClass(core_kernel_classes_Class $class): void
+    {
+        $rootClass = $class->getClass(TaoOntology::CLASS_URI_TEST);
+
+        if (!$class->equals($rootClass) && !$class->isSubClassOf($rootClass)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Selected class (%s) is not supported because it is not part of the root class (%s).',
+                    $class->getUri(),
+                    TaoOntology::CLASS_URI_TEST
+                )
+            );
+        }
+    }
+}

--- a/models/classes/Copier/TestContentCopier.php
+++ b/models/classes/Copier/TestContentCopier.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\models\Copier;
+
+use core_kernel_classes_Resource;
+use oat\oatbox\event\EventManager;
+use oat\generis\model\fileReference\FileReferenceSerializer;
+use oat\tao\model\resources\Contract\InstanceContentCopierInterface;
+use taoTests_models_classes_TestsService;
+
+class TestContentCopier implements InstanceContentCopierInterface
+{
+    private FileReferenceSerializer $fileReferenceSerializer;
+    private taoTests_models_classes_TestsService $testsService;
+    private EventManager $eventManager;
+
+    public function __construct(
+        FileReferenceSerializer $fileReferenceSerializer,
+        taoTests_models_classes_TestsService $testsService,
+        EventManager $eventManager
+    ) {
+        $this->fileReferenceSerializer = $fileReferenceSerializer;
+        $this->testsService = $testsService;
+        $this->eventManager = $eventManager;
+    }
+
+    public function copy(
+        core_kernel_classes_Resource $instance,
+        core_kernel_classes_Resource $destinationInstance
+    ): void {
+    }
+}

--- a/models/classes/class.TestsService.php
+++ b/models/classes/class.TestsService.php
@@ -21,6 +21,7 @@
  *               2012-2021 (original work) Open Assessment Technologies SA;
  */
 use oat\generis\model\OntologyRdf;
+use oat\tao\model\resources\Service\InstanceCopier;
 use oat\tao\model\TaoOntology;
 use oat\taoTests\models\event\TestCreatedEvent;
 use oat\taoTests\models\event\TestDuplicatedEvent;
@@ -142,6 +143,7 @@ class taoTests_models_classes_TestsService extends OntologyClassService
 
     /**
      * @author Joel Bout, <joel.bout@tudor.lu>
+     * @deprecated Use service id 'oat\tao\model\resources\Service\InstanceCopier::TESTS'
      */
     public function cloneInstance(core_kernel_classes_Resource $instance, core_kernel_classes_Class $clazz = null): ?core_kernel_classes_Resource
     {
@@ -174,15 +176,19 @@ class taoTests_models_classes_TestsService extends OntologyClassService
             }
             $clone->setLabel($cloneLabel);
 
-            $impl = $this->getTestModelImplementation($this->getTestModel($instance));
-            $impl->cloneContent($instance, $clone);
-
+            $this->cloneContent($instance, $clone);
             $this->getEventManager()->trigger(new TestDuplicatedEvent($instance->getUri(), $clone->getUri()));
 
             $returnValue = $clone;
         }
 
         return $returnValue;
+    }
+
+    public function cloneContent(core_kernel_classes_Resource $original, core_kernel_classes_Resource $clone): void
+    {
+        $impl = $this->getTestModelImplementation($this->getTestModel($original));
+        $impl->cloneContent($original, $clone);
     }
 
     /**

--- a/test/unit/models/classes/Copier/TestClassCopierTest.php
+++ b/test/unit/models/classes/Copier/TestClassCopierTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\test\unit\models\classes\Copier;
+
+use oat\generis\model\data\Ontology;
+use oat\generis\test\MockObject;
+use oat\tao\model\resources\Contract\ResourceTransferInterface;
+use oat\taoTests\models\Copier\TestClassCopier;
+use PHPUnit\Framework\TestCase;
+
+class TestClassCopierTest extends TestCase
+{
+    /** @var ResourceTransferInterface|MockObject */
+    private $classCopier;
+    /** @var Ontology|MockObject */
+    private $ontology;
+    private TestClassCopier $sut;
+
+    public function setUp(): void
+    {
+        $this->classCopier = $this->createMock(ResourceTransferInterface::class);
+        $this->ontology = $this->createMock(Ontology::class);
+        $this->sut = new TestClassCopier($this->classCopier, $this->ontology);
+    }
+
+    public function testTransfer(): void
+    {
+        //@TODO Finish test.
+    }
+}

--- a/test/unit/models/classes/Copier/TestContentCopierTest.php
+++ b/test/unit/models/classes/Copier/TestContentCopierTest.php
@@ -22,8 +22,11 @@ declare(strict_types=1);
 
 namespace oat\taoTests\test\unit\models\classes\Copier;
 
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
 use oat\oatbox\event\EventManager;
 use oat\taoTests\models\Copier\TestContentCopier;
+use oat\taoTests\models\event\TestDuplicatedEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use taoTests_models_classes_TestsService;
@@ -45,6 +48,41 @@ class TestContentCopierTest extends TestCase
 
     public function testCopy(): void
     {
-        //@TODO finish test
+        $fromInstance = $this->createMock(core_kernel_classes_Resource::class);
+        $toInstance = $this->createMock(core_kernel_classes_Resource::class);
+        $modelProperty = $this->createMock(core_kernel_classes_Property::class);
+        $model = $this->createMock(core_kernel_classes_Resource::class);
+
+        $fromInstance->expects($this->once())
+            ->method('getUri')
+            ->willReturn('fromUri');
+
+        $fromInstance->expects($this->once())
+            ->method('getProperty')
+            ->willReturn($modelProperty);
+
+        $fromInstance->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->willReturn($model);
+
+        $toInstance->expects($this->once())
+            ->method('getUri')
+            ->willReturn('toUri');
+
+        $toInstance->expects($this->once())
+            ->method('editPropertyValues')
+            ->with($modelProperty, $model);
+
+        $this->testsService
+            ->expects($this->once())
+            ->method('cloneContent')
+            ->with($fromInstance, $toInstance);
+
+        $this->eventManager
+            ->expects($this->once())
+            ->method('trigger')
+            ->with(new TestDuplicatedEvent('fromUri', 'toUri'));
+
+        $this->sut->copy($fromInstance, $toInstance);
     }
 }

--- a/test/unit/models/classes/Copier/TestContentCopierTest.php
+++ b/test/unit/models/classes/Copier/TestContentCopierTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\test\unit\models\classes\Copier;
+
+use oat\oatbox\event\EventManager;
+use oat\taoTests\models\Copier\TestContentCopier;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use taoTests_models_classes_TestsService;
+
+class TestContentCopierTest extends TestCase
+{
+    /** @var EventManager|MockObject */
+    private $eventManager;
+    /** @var MockObject|taoTests_models_classes_TestsService */
+    private $testsService;
+    private TestContentCopier $sut;
+
+    public function setUp(): void
+    {
+        $this->testsService = $this->createMock(taoTests_models_classes_TestsService::class);
+        $this->eventManager = $this->createMock(EventManager::class);
+        $this->sut = new TestContentCopier($this->testsService, $this->eventManager);
+    }
+
+    public function testCopy(): void
+    {
+        //@TODO finish test
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/RFE-530
https://oat-sa.atlassian.net/browse/ADF-1424
https://oat-sa.atlassian.net/browse/ADF-1425
https://oat-sa.atlassian.net/browse/ADF-1426
https://oat-sa.atlassian.net/browse/ADF-1427

# Goal

Add dynamic ACL strategy to `Move to` and `Copy to` features

# How to test

- Login to backoffice
- Play with the new ACL options for Items/Assets/Tests

# Related PRs

- https://github.com/oat-sa/extension-tao-item/pull/607
- https://github.com/oat-sa/extension-tao-mediamanager/pull/462
- https://github.com/oat-sa/tao-core/pull/3776
- https://github.com/oat-sa/extension-tao-dac-simple/pull/216
- https://github.com/oat-sa/generis/pull/1036