### PR TITLE
fix: move restricted test author role to taoTests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,9 @@
  * @license GPLv2  http://www.opensource.org/licenses/gpl-2.0.php
  */
 
+use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
+use oat\taoTest\models\classes\user\TaoTestRoles;
 use oat\taoTests\models\Copier\CopierServiceProvider;
 use oat\taoTests\scripts\update\Updater;
 use oat\taoTests\scripts\install\SetupProvider;
@@ -65,8 +67,21 @@ return [
     'update' => Updater::class,
     'managementRole' => 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole',
     'acl' => [
-        ['grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole', ['ext' => 'taoTests']],
-        ['grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoTests', 'mod' => 'RestTests']],
+        [
+            AccessRule::GRANT,
+            TaoTestRoles::TEST_MANAGER,
+            ['ext' => 'taoTests']
+        ],
+        [
+            AccessRule::GRANT,
+            TaoRoles::REST_PUBLISHER,
+            ['ext' => 'taoTests', 'mod' => 'RestTests']
+        ],
+        [
+            AccessRule::GRANT,
+            TaoTestRoles::RESTRICTED_TEST_AUTHOR,
+            ['ext' => 'taoTests', 'mod' => 'Tests']
+        ]
     ],
     'optimizableClasses' => [
         'http://www.tao.lu/Ontologies/TAOTest.rdf#Test',

--- a/migrations/Version202307100801342363_taoTests.php
+++ b/migrations/Version202307100801342363_taoTests.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoTests\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoTest\models\classes\user\TaoTestRoles;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202307100801342363_taoTests extends AbstractMigration
+{
+    private const CONFIG = [
+        SetRolesAccess::CONFIG_RULES => [
+            TaoTestRoles::RESTRICTED_TEST_AUTHOR => [
+                ['ext' => 'taoTests', 'mod' => 'Tests']
+            ]
+        ],
+    ];
+    public function getDescription(): string
+    {
+        return 'Add role access to restricted test author';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_REVOKE,
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+}

--- a/models/classes/user/TaoTestRoles.php
+++ b/models/classes/user/TaoTestRoles.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTest\models\classes\user;
+
+interface TaoTestRoles
+{
+    public const TEST_AUTHOR = 'http://www.tao.lu/Ontologies/TAOItem.rdf#TestAuthor';
+    public const TEST_MANAGER = 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole';
+    public const RESTRICTED_TEST_AUTHOR = 'http://www.tao.lu/Ontologies/TAO.rdf#RestrictedTestAuthor';
+}

--- a/models/ontology/taotest.rdf
+++ b/models/ontology/taotest.rdf
@@ -52,7 +52,14 @@
   	<rdfs:label xml:lang="en-US"><![CDATA[Tests Manager]]></rdfs:label>
     <rdfs:comment xml:lang="en-US"><![CDATA[The Tests Manager Role]]></rdfs:comment>
   </rdf:Description>
-  
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#RestrictedTestAuthor">
+  	<rdf:type rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#UserRole"/>
+   	<generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#PropertyManagerRole"/>
+   	<generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#TestXMLEditor"/>
+   	<generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole"/>
+   	<rdfs:label xml:lang="en-US"><![CDATA[Restricted Test Author]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Test Author with limitation for ACL]]></rdfs:comment>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#TestAuthor">
   	<rdf:type rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#UserRole"/>
   	<generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole"/>


### PR DESCRIPTION
Move RESTRICTED_TEST_AUTHOR from taoDacSimple to correct domain

https://github.com/oat-sa/extension-tao-dac-simple/pull/233