### PR TITLE
Feature/ADF-1695/Show multiple preview buttons

### DIFF
--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -39,7 +39,18 @@ define([
             }).filter(([key, value]) => value !== undefined)
         );
 
-        previewerFactory(config.provider,
+        const getProvider = id => {
+            if (!id || !config.providers) {
+                return config.provider
+            }
+            const previewerId = parseInt(`${id}`.split('-').pop(), 10) || 0;
+            if (!config.providers[previewerId]) {
+                return config.provider;
+            }
+            return config.providers[previewerId].id;
+        };
+
+        previewerFactory(getProvider(this.id) || 'qtiTest',
             uri.decode(actionContext.uri),
             previewerConfig)
             .catch(err => {

--- a/views/js/controller/tests/action.js
+++ b/views/js/controller/tests/action.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 - 2020 (original work) Open Assessment Techniologies SA
+ * Copyright (c) 2014 - 2020 (original work) Open Assessment Technologies SA
  *
  */
 define([
@@ -24,7 +24,7 @@ define([
     'core/logger',
     'taoTests/previewer/factory',
     'module'
-], function(__, binder, uri, feedback, loggerFactory, previewerFactory, module){
+], function (__, binder, uri, feedback, loggerFactory, previewerFactory, module) {
     'use strict';
 
     const logger = loggerFactory('taoTests/controller/action');
@@ -41,7 +41,7 @@ define([
 
         const getProvider = id => {
             if (!id || !config.providers) {
-                return config.provider
+                return config.provider;
             }
             const previewerId = parseInt(`${id}`.split('-').pop(), 10) || 0;
             if (!config.providers[previewerId]) {
@@ -50,12 +50,11 @@ define([
             return config.providers[previewerId].id;
         };
 
-        previewerFactory(getProvider(this.id) || 'qtiTest',
-            uri.decode(actionContext.uri),
-            previewerConfig)
-            .catch(err => {
+        previewerFactory(getProvider(this.id) || 'qtiTest', uri.decode(actionContext.uri), previewerConfig).catch(
+            err => {
                 logger.error(err);
                 feedback().error(__('Test Preview is not installed, please contact to your administrator.'));
-            });
+            }
+        );
     });
 });

--- a/views/js/controller/tests/editTest.js
+++ b/views/js/controller/tests/editTest.js
@@ -20,25 +20,20 @@
  * Test edition controller
  *
  */
-define([
-    'jquery',
-    'ui/lock',
-    'module',
-    'layout/actions',
-],	function($, lock, module, actions){
+define(['jquery', 'ui/lock', 'module', 'layout/actions'], function ($, lock, module, actions) {
     'use strict';
 
     return {
         /**
          * Controller's entrypoint
          */
-        start(){
-
+        start() {
             const config = module.config();
+            const maxButtons = 10; // arbitrary value for the max number of buttons
 
             const getPreviewId = idx => `test-preview${idx ? `-${idx}` : ''}`;
-            const previewActions = []
-            for (let i = 0; i < 10; i++) {
+            const previewActions = [];
+            for (let i = 0; i < maxButtons; i++) {
                 const action = actions.getBy(getPreviewId(i));
                 if (!action) {
                     break;
@@ -47,10 +42,10 @@ define([
             }
             previewActions.forEach(previewAction => {
                 previewAction.state.disabled = !config.isPreviewEnabled;
-            })
+            });
             actions.updateState();
 
-            $('#lock-box').each(function() {
+            $('#lock-box').each(function () {
                 lock($(this)).register();
             });
         }

--- a/views/js/controller/tests/editTest.js
+++ b/views/js/controller/tests/editTest.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015-2019 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2024 (original work) Open Assessment Technologies SA;
  */
 
 /**
@@ -29,19 +29,26 @@ define([
     'use strict';
 
     return {
-
-
         /**
          * Controller's entrypoint
          */
         start(){
 
             const config = module.config();
-            const previewAction = actions.getBy('test-preview');
-            if (previewAction) {
-                previewAction.state.disabled = !config.isPreviewEnabled;
-                actions.updateState();
+
+            const getPreviewId = idx => `test-preview${idx ? `-${idx}` : ''}`;
+            const previewActions = []
+            for (let i = 0; i < 10; i++) {
+                const action = actions.getBy(getPreviewId(i));
+                if (!action) {
+                    break;
+                }
+                previewActions.push(action);
             }
+            previewActions.forEach(previewAction => {
+                previewAction.state.disabled = !config.isPreviewEnabled;
+            })
+            actions.updateState();
 
             $('#lock-box').each(function() {
                 lock($(this)).register();


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1695

### Summary

Add the possibility of having more than one test previewer.

### Details

It supports multiple preview buttons from the test's property page.

This is made thanks to a configuration applied in `config/tao/client_lib_config_registry.conf.php`, and a change applied to the `structures.xml` file.

- **structures.xml**
Each button must be declared with an identifier starting with `test-preview`. The first button must be `test-preview`, the second `test-preview-1`, etc. The suffix number refers to a position in the configuration (see `client_lib_config_registry.conf.php`).
Example:
```xml
    <structure id="tests" name="Tests" level="1" group="main">
        <sections>
            <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                <actions allowClassActions="true">
                    <action id="test-preview" name="Preview" url="/taoTests/Tests/index" context="instance" group="content" binding="testPreview">
                        <icon id="icon-preview"/>
                    </action>
                    <action id="test-preview-1" name="Preview (legacy)" url="/taoTests/Tests/index" context="instance" group="content" binding="testPreview">
                        <icon id="icon-preview"/>
                    </action>
                </actions>
            </section>
        </sections>
    </structure>
```

- **client_lib_config_registry.conf.php**
The configuration can be extended with a list of possible providers, aside from the default one. This is done in `config/tao/client_lib_config_registry.conf.php`.
Example:
```php
        'taoTests/controller/tests/action' => array(
            'provider' => 'qtiTestNUI',
            'providers' => array(
                array(
                    'id' => 'qtiTestNUI',
                    'label' => 'Preview'
                ),
                array(
                    'id' => 'qtiTest',
                    'label' => 'Preview (legacy)'
                )
            )
        ),
```

### How to test

- checkout the branch: `git checkout -t origin/feature/ADF-1695/multiple-preview-buttons`
- also checkout the branches from the companion PR
- make sure to have set the appropriate configuration (check the details in the ticket)