### PR TITLE
Feature/ADF-1788/Add the translation list UI

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -70,7 +70,7 @@
                         <icon id="icon-test"/>
                     </action>
                     <action id="test-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateTest">
-                        <icon id="icon-spell-check"/>
+                        <icon id="icon-replace"/>
                     </action>
                 </actions>
             </section>


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1788

### Summary

Add the action for managing the list of translations.

<img width="1712" alt="image" src="https://github.com/user-attachments/assets/4c833c63-c548-4758-8a63-9023256eb44c">

### Details

Add the translate action and wire it with the translation component and service.

### How to test

- checkout the branch: `git checkout -t origin/feature/ADF-1788/translation-list-ui`
- make sure to also install the companion PR (`feat/HKD-6/integration` on other repos)
- select a test and see the translate button
- click the translate button (note: you need the test to be ready for translation, otherwise, the component will only show a placeholder message)

The following feature flags will also be needed:
```
FEATURE_FLAG_TRANSLATION_ENABLED=true
FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER=true
```