### PR TITLE
feature/ADF-1789/Forward the translation parameters

### DIFF
--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -241,6 +241,15 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
             if (!empty($authoringUrl)) {
                 $userId = common_session_SessionManager::getSession()->getUser()->getIdentifier();
                 LockManager::getImplementation()->setLock($test, $userId);
+
+                // Add support for the translation and the side-by-side authoring tool
+                if ($this->getRequestParameter('translation') !== null) {
+                    $authoringUrl = sprintf('%s&translation=%s', $authoringUrl, $this->getRequestParameter('translation'));
+                }
+                if ($this->getRequestParameter('originResourceUri') !== null) {
+                    $authoringUrl = sprintf('%s&originResourceUri=%s', $authoringUrl, $this->getRequestParameter('originResourceUri'));
+                }
+
                 return $this->forwardUrl($authoringUrl);
             }
             throw new common_exception_NoImplementation();


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1789

### Summary

Forward the translation parameters to the authoring.

### Details

This is a technical change only. It adds support for the translation mode, forwarding:
- `translation`: `bool` - A flag telling if we are translating a test. Can be `null`.
- `originResourceUri`: `string` - The URI of the original test being translated. Can be `null`.