### PR TITLE
fix/ADF-1827/sync-translations-on-authoring

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.4', '8.0', '8.1' ]
+        php-version: [ '8.0', '8.1' ]
         include:
           - php-version: '8.1'
             coverage: true

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -41,6 +41,7 @@ use oat\generis\model\resource\Contract\ResourceDeleterInterface;
 use oat\generis\model\resource\exception\ResourceDeletionException;
 use oat\tao\model\resources\Exception\PartialClassDeletionException;
 use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
+use oat\tao\model\Translation\Service\TranslationSyncService;
 
 /**
  * Tests Controller provide actions performed from url resolution
@@ -331,5 +332,10 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
     private function getResourceDeleter(): ResourceDeleterInterface
     {
         return $this->getPsrContainer()->get(ResourceDeleter::class);
+    }
+
+    private function getTranslationSyncService(): TranslationSyncService
+    {
+        return $this->getPsrContainer()->get(TranslationSyncService::class);
     }
 }

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -251,6 +251,7 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
                     );
                 }
                 if ($this->getRequestParameter('originResourceUri') !== null) {
+                    $this->getTranslationSyncService()->syncById($this->getRequestParameter('originResourceUri'));
                     $authoringUrl = sprintf(
                         '%s&originResourceUri=%s',
                         $authoringUrl,

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.39.0",
-        "oat-sa/tao-core": ">=54.25.0",
+        "oat-sa/tao-core": ">=54.27.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0",
         "oat-sa/extension-tao-item": ">=12.5.0"
     },


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1827


### Description

Once `originResourceUri` is provided to the authoring call, sync the translations

### How to test

checkout related tao branches 
 - https://github.com/oat-sa/tao-core/tree/fix/ADF-1827/add-sync-by-id
 - https://github.com/oat-sa/extension-tao-testqti/tree/fix/ADF-1827/remove-translation-sync-call

#### Steps to reproduce / check if issue is fixed:
 
 - create an item
 - create test 
 - add item to the test 
 - create test translation to some language, save it
 - add translation to the item in that language
 - go back to tests and edit the translation of the test you have created

label should exist for the item