### PR TITLE
fix: allow to sync test metadata to DataStore after translation sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.39.0",
-        "oat-sa/tao-core": ">=54.27.0",
+        "oat-sa/tao-core": ">=54.28.5",
         "oat-sa/extension-tao-backoffice": ">=6.0.0",
         "oat-sa/extension-tao-item": ">=12.5.0"
     },

--- a/models/classes/Translation/Service/TranslateIntoLanguagesHandler.php
+++ b/models/classes/Translation/Service/TranslateIntoLanguagesHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTests\models\Translation\Service;
+
+use core_kernel_classes_Resource;
+use oat\oatbox\event\EventManager;
+use oat\taoTests\models\event\TestUpdatedEvent;
+use Psr\Log\LoggerInterface;
+
+class TranslateIntoLanguagesHandler
+{
+    private LoggerInterface $logger;
+    private EventManager $eventManager;
+
+    public function __construct(LoggerInterface $logger, EventManager $eventManager)
+    {
+        $this->logger = $logger;
+        $this->eventManager = $eventManager;
+    }
+
+    public function __invoke(core_kernel_classes_Resource $originalTest): void
+    {
+        $this->logger->debug(sprintf('Force original test sync %s at %s', $originalTest->getUri(), __METHOD__));
+
+        $this->eventManager->trigger(new TestUpdatedEvent($originalTest->getUri()));
+    }
+}

--- a/test/unit/models/classes/Translation/Service/TranslateIntoLanguagesHandlerTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslateIntoLanguagesHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace unit\models\classes\Translation\Service;
+
+use core_kernel_classes_Resource;
+use oat\oatbox\event\EventManager;
+use oat\taoTests\models\Translation\Service\TranslateIntoLanguagesHandler;
+use oat\taoTests\models\event\TestUpdatedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class TranslateIntoLanguagesHandlerTest extends TestCase
+{
+    private TranslateIntoLanguagesHandler $handler;
+
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    /** @var EventManager|MockObject */
+    private $eventManager;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->eventManager = $this->createMock(EventManager::class);
+
+        $this->handler = new TranslateIntoLanguagesHandler($this->logger, $this->eventManager);
+    }
+
+    public function testInvoke(): void
+    {
+        $resourceUri = 'http://example.com/resource/1';
+        $resource = $this->createMock(core_kernel_classes_Resource::class);
+        $resource
+            ->method('getUri')
+            ->willReturn($resourceUri);
+
+        $this->eventManager
+            ->expects($this->once())
+            ->method('trigger')
+            ->with(new TestUpdatedEvent($resourceUri));
+
+        $this->handler->__invoke($resource);
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1855

# Goal 

Allow callbacks to be executed for original test after sync it


# Related PRs

- https://github.com/oat-sa/tao-core/pull/4158