### PR TITLE
fix: use copy-to icon for quickwins design

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -55,7 +55,7 @@
                         <icon id="icon-copy"/>
                     </action>
                     <action id="test-copy-to" name="Copy To" url="/taoTests/Tests/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-copy" alt="icon-copy-to"/>
                     </action>
                     <action id="test-move-to" name="Move To" url="/taoTests/Tests/moveResource" context="instance" group="tree" binding="moveTo" weight="6">
                         <icon id="icon-move-item"/>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -52,10 +52,10 @@
                         <icon id="icon-export"/>
                     </action>
                     <action id="test-duplicate" name="Duplicate" js="duplicateNode" url="/taoTests/Tests/cloneInstance" context="instance" group="tree" weight="8">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-duplicate"/>
                     </action>
                     <action id="test-copy-to" name="Copy To" url="/taoTests/Tests/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
-                        <icon id="icon-copy" alt="icon-copy-to"/>
+                        <icon id="icon-copy"/>
                     </action>
                     <action id="test-move-to" name="Move To" url="/taoTests/Tests/moveResource" context="instance" group="tree" binding="moveTo" weight="6">
                         <icon id="icon-move-item"/>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4061

## What's Changed

- Added support of alternative icon, specifically alternative for the `Copy` icon

## How to test

- Run the app with FEATURE_FLAG_QUICK_WINS_ENABLED FF enabled
- Check Copy to icons are updated accordingly