### PR TITLE
fix: Temporary Feature flag to disable QTI3 export

### DIFF
--- a/actions/class.TestExport.php
+++ b/actions/class.TestExport.php
@@ -41,7 +41,7 @@ use tao_models_classes_export_ExportHandler as ExportHandlerInterface;
 class taoTests_actions_TestExport extends tao_actions_Export
 {
     //TODO: This was created only to temporary handle QTI3 Export feature. Will be removed.
-    const QTI3_TEST_HANDLER = 'oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport';
+    private const QTI3_TEST_HANDLER = 'oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport';
     private const FEATURE_FLAG_QTI3_EXPORT = 'FEATURE_FLAG_QTI3_EXPORT';
 
     /**

--- a/actions/class.TestExport.php
+++ b/actions/class.TestExport.php
@@ -71,10 +71,9 @@ class taoTests_actions_TestExport extends tao_actions_Export
             $impl = taoTests_models_classes_TestsService::singleton()->getTestModelImplementation($model);
             if (in_array('tao_models_classes_export_ExportProvider', class_implements($impl))) {
                 foreach ($impl->getExportHandlers() as $handler) {
-                    if($this->isHandlerEnabled($handler)) {
+                    if ($this->isHandlerEnabled($handler)) {
                         array_unshift($returnValue, $handler);
                     }
-
                 }
             }
         }
@@ -89,7 +88,8 @@ class taoTests_actions_TestExport extends tao_actions_Export
      */
     private function isHandlerEnabled(tao_models_classes_export_ExportHandler $handler): bool
     {
-        if ($handler instanceof TestPackageExport
+        if (
+            $handler instanceof TestPackageExport
             && !$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(self::FEATURE_FLAG_QTI3_EXPORT)
         ) {
             return false;

--- a/actions/class.TestExport.php
+++ b/actions/class.TestExport.php
@@ -25,10 +25,11 @@
  */
 
 use oat\tao\model\featureFlag\FeatureFlagChecker;
-use oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport;
+use oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport as Qti3Handler;
 use oat\taoTests\models\MissingTestmodelException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use tao_models_classes_export_ExportHandler as ExportHandlerInterface;
 
 /**
  * This controller provide the actions to export tests
@@ -86,10 +87,10 @@ class taoTests_actions_TestExport extends tao_actions_Export
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    private function isHandlerEnabled(tao_models_classes_export_ExportHandler $handler): bool
+    private function isHandlerEnabled(ExportHandlerInterface $handler): bool
     {
         if (
-            $handler instanceof TestPackageExport
+            $handler instanceof Qti3Handler
             && !$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(self::FEATURE_FLAG_QTI3_EXPORT)
         ) {
             return false;

--- a/actions/class.TestExport.php
+++ b/actions/class.TestExport.php
@@ -21,9 +21,14 @@
  *                         (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor
  *                         (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2012-2025 (update and modification) Open Assessment Technologies SA;
  */
 
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport;
 use oat\taoTests\models\MissingTestmodelException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * This controller provide the actions to export tests
@@ -35,6 +40,8 @@ use oat\taoTests\models\MissingTestmodelException;
  */
 class taoTests_actions_TestExport extends tao_actions_Export
 {
+    private const FEATURE_FLAG_QTI3_EXPORT = 'FEATURE_FLAG_QTI3_EXPORT';
+
     /**
      * overwrite the parent index to add the requiresRight for Tests
      *
@@ -64,11 +71,30 @@ class taoTests_actions_TestExport extends tao_actions_Export
             $impl = taoTests_models_classes_TestsService::singleton()->getTestModelImplementation($model);
             if (in_array('tao_models_classes_export_ExportProvider', class_implements($impl))) {
                 foreach ($impl->getExportHandlers() as $handler) {
-                    array_unshift($returnValue, $handler);
+                    if($this->isHandlerEnabled($handler)) {
+                        array_unshift($returnValue, $handler);
+                    }
+
                 }
             }
         }
 
         return $returnValue;
+    }
+
+    /**
+     * TODO: This was created only to temporary handle QTI3 Export feature. Will be removed.
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    private function isHandlerEnabled(tao_models_classes_export_ExportHandler $handler): bool
+    {
+        if ($handler instanceof TestPackageExport
+            && !$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(self::FEATURE_FLAG_QTI3_EXPORT)
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/actions/class.TestExport.php
+++ b/actions/class.TestExport.php
@@ -25,7 +25,6 @@
  */
 
 use oat\tao\model\featureFlag\FeatureFlagChecker;
-use oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport as Qti3Handler;
 use oat\taoTests\models\MissingTestmodelException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -41,6 +40,8 @@ use tao_models_classes_export_ExportHandler as ExportHandlerInterface;
  */
 class taoTests_actions_TestExport extends tao_actions_Export
 {
+    //TODO: This was created only to temporary handle QTI3 Export feature. Will be removed.
+    const QTI3_TEST_HANDLER = 'oat\taoQtiTest\models\export\Formats\Package3p0\TestPackageExport';
     private const FEATURE_FLAG_QTI3_EXPORT = 'FEATURE_FLAG_QTI3_EXPORT';
 
     /**
@@ -90,7 +91,7 @@ class taoTests_actions_TestExport extends tao_actions_Export
     private function isHandlerEnabled(ExportHandlerInterface $handler): bool
     {
         if (
-            $handler instanceof Qti3Handler
+            $handler instanceof self::QTI3_TEST_HANDLER
             && !$this->getPsrContainer()->get(FeatureFlagChecker::class)->isEnabled(self::FEATURE_FLAG_QTI3_EXPORT)
         ) {
             return false;


### PR DESCRIPTION
This hide QTI 3  test export in user interface base on `FEATURE_FLAG_QTI3_EXPORT`. 

QTI 3 Export is disabled by default. 