### PR TITLE
fix: only test author can access test preview

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,2 @@
 remote_config:
-    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/refs/heads/main/coderabbit/php/authoring/v1/.coderabbit.yaml'
+    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/main/coderabbit/php/authoring/v1/.coderabbit.yaml'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+remote_config:
+    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/refs/heads/main/coderabbit/php/authoring/v1/.coderabbit.yaml'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,2 @@
 remote_config:
-    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/main/coderabbit/php/authoring/v1/.coderabbit.yaml'
+  url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/main/coderabbit/php/authoring/v1/.coderabbit.yaml'

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -85,6 +85,13 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
     * controller actions
     */
 
+    /**
+     * @requiresRight id READ
+     */
+    public function preview(): void
+    {
+        $this->index();
+    }
 
     /**
      * edit a test instance

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -149,11 +149,16 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
             if ($hasWriteAccess) {
                 if ($myForm->isSubmited() && $myForm->isValid()) {
                     $this->validateInstanceRoot($test->getUri());
-    
+
                     $propertyValues = $myForm->getValues();
-    
+
                     // don't hande the testmodel via bindProperties
-                    if (array_key_exists(taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL, $propertyValues)) {
+                    if (
+                        array_key_exists(
+                            taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL,
+                            $propertyValues
+                        )
+                    ) {
                         $modelUri = $propertyValues[taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL];
                         unset($propertyValues[taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL]);
                         if (!empty($modelUri)) {
@@ -163,12 +168,12 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
                     } else {
                         common_Logger::w('No testmodel on test form', 'taoTests');
                     }
-    
+
                     //then save the property values as usual
                     $binder = new tao_models_classes_dataBinding_GenerisFormDataBinder($test);
                     $test = $binder->bind($propertyValues);
                     $this->getEventManager()->trigger(new TestUpdatedEvent($test->getUri(), $propertyValues));
-    
+
                     $this->setData('selectNode', tao_helpers_Uri::encode($test->getUri()));
                     $this->setData('message', __('Test saved'));
                     $this->setData('reload', true);

--- a/actions/class.Tests.php
+++ b/actions/class.Tests.php
@@ -26,6 +26,7 @@
 use oat\oatbox\event\EventManager;
 use oat\tao\model\lock\LockManager;
 use oat\oatbox\validator\ValidatorInterface;
+use oat\tao\model\accessControl\Context;
 use oat\tao\model\resources\ResourceWatcher;
 use oat\tao\model\TaoOntology;
 use oat\taoTests\models\event\TestUpdatedEvent;
@@ -113,11 +114,20 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
                 $this->setData('id', $lock->getResource()->getUri());
             }
 
+            $context = new Context(
+                [
+                    Context::PARAM_CONTROLLER => self::class,
+                    Context::PARAM_ACTION => __FUNCTION__,
+                ]
+            );
+            $hasWriteAccess = $this->hasWriteAccess($test->getUri()) && $this->hasWriteAccessByContext($context);
+
             $clazz = $this->getCurrentClass();
             $formContainer = new SignedFormInstance(
                 $clazz,
                 $test,
                 [
+                    FormContainer::IS_DISABLED => !$hasWriteAccess,
                     FormContainer::CSRF_PROTECTION_OPTION => true,
                     FormContainer::ATTRIBUTE_VALIDATORS => [
                         'data-depends-on-property' => [
@@ -136,31 +146,35 @@ class taoTests_actions_Tests extends tao_actions_SaSModule
                 'resourceType' => TaoOntology::CLASS_URI_TEST
             ]);
 
-            if ($myForm->isSubmited() && $myForm->isValid()) {
-                $this->validateInstanceRoot($test->getUri());
-
-                $propertyValues = $myForm->getValues();
-
-                // don't hande the testmodel via bindProperties
-                if (array_key_exists(taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL, $propertyValues)) {
-                    $modelUri = $propertyValues[taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL];
-                    unset($propertyValues[taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL]);
-                    if (!empty($modelUri)) {
-                        $testModel = new core_kernel_classes_Resource($modelUri);
-                        $this->service->setTestModel($test, $testModel);
+            if ($hasWriteAccess) {
+                if ($myForm->isSubmited() && $myForm->isValid()) {
+                    $this->validateInstanceRoot($test->getUri());
+    
+                    $propertyValues = $myForm->getValues();
+    
+                    // don't hande the testmodel via bindProperties
+                    if (array_key_exists(taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL, $propertyValues)) {
+                        $modelUri = $propertyValues[taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL];
+                        unset($propertyValues[taoTests_models_classes_TestsService::PROPERTY_TEST_TESTMODEL]);
+                        if (!empty($modelUri)) {
+                            $testModel = new core_kernel_classes_Resource($modelUri);
+                            $this->service->setTestModel($test, $testModel);
+                        }
+                    } else {
+                        common_Logger::w('No testmodel on test form', 'taoTests');
                     }
-                } else {
-                    common_Logger::w('No testmodel on test form', 'taoTests');
+    
+                    //then save the property values as usual
+                    $binder = new tao_models_classes_dataBinding_GenerisFormDataBinder($test);
+                    $test = $binder->bind($propertyValues);
+                    $this->getEventManager()->trigger(new TestUpdatedEvent($test->getUri(), $propertyValues));
+    
+                    $this->setData('selectNode', tao_helpers_Uri::encode($test->getUri()));
+                    $this->setData('message', __('Test saved'));
+                    $this->setData('reload', true);
                 }
-
-                //then save the property values as usual
-                $binder = new tao_models_classes_dataBinding_GenerisFormDataBinder($test);
-                $test = $binder->bind($propertyValues);
-                $this->getEventManager()->trigger(new TestUpdatedEvent($test->getUri(), $propertyValues));
-
-                $this->setData('selectNode', tao_helpers_Uri::encode($test->getUri()));
-                $this->setData('message', __('Test saved'));
-                $this->setData('reload', true);
+            } else {
+                $myForm->setActions([]);
             }
 
             $myForm->removeElement(tao_helpers_Uri::encode(

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -27,7 +27,7 @@
                     <action id="test-properties"  name="Properties"  url="/taoTests/Tests/editTest" group="content" context="instance">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-preview" name="Preview" url="/taoTests/Tests/index" context="instance" group="content" binding="testPreview">
+                    <action id="test-preview" name="Preview" url="/taoTests/Tests/preview" context="instance" group="content" binding="testPreview">
                         <icon id="icon-preview"/>
                     </action>
                     <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor">

--- a/manifest.php
+++ b/manifest.php
@@ -85,6 +85,11 @@ return [
         ],
         [
             AccessRule::GRANT,
+            TaoTestsRoles::TEST_AUTHOR,
+            ['ext' => 'taoTests', 'mod' => 'Tests', 'act' => 'preview'],
+        ],
+        [
+            AccessRule::GRANT,
             TaoTestsRoles::TEST_EXPORTER,
             ['ext' => 'taoTests', 'mod' => 'TestExport']
         ],

--- a/migrations/Version202506050743452143_taoTests.php
+++ b/migrations/Version202506050743452143_taoTests.php
@@ -14,7 +14,7 @@ final class Version202506050743452143_taoTests extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add new Test Manager Role to access tests preview';
+        return sprintf('Give role %s access tests preview', TaoTestsRoles::TEST_AUTHOR);
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version202506050743452143_taoTests.php
+++ b/migrations/Version202506050743452143_taoTests.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoTests\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTests\models\user\TaoTestsRoles;
+
+final class Version202506050743452143_taoTests extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add new Test Manager Role to access tests preview';
+    }
+
+    public function up(Schema $schema): void
+    {
+        AclProxy::applyRule($this->getRule());
+    }
+
+    public function down(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getRule());
+    }
+
+    private function getRule(): AccessRule
+    {
+        return new AccessRule(
+            AccessRule::GRANT,
+            TaoTestsRoles::TEST_AUTHOR,
+            ['ext' => 'taoTests', 'mod' => 'Tests', 'act' => 'preview']
+        );
+    }
+}

--- a/models/classes/user/TaoTestsRoles.php
+++ b/models/classes/user/TaoTestsRoles.php
@@ -29,4 +29,5 @@ interface TaoTestsRoles
     public const TEST_MANAGER = 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole';
     public const RESTRICTED_TEST_AUTHOR = 'http://www.tao.lu/Ontologies/TAO.rdf#RestrictedTestAuthor';
     public const TEST_TRANSLATOR = 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestTranslator';
+    public const TEST_AUTHOR = 'http://www.tao.lu/Ontologies/TAOItem.rdf#TestAuthor';
 }


### PR DESCRIPTION
## Ticket:

https://oat-sa.atlassian.net/browse/ADF-1976

## Dependencies PRs

https://github.com/oat-sa/extension-tao-testqti-previewer/pull/218

Now the preview buttons does not appear in case of no access allowed.

![Screenshot 2025-06-05 at 11 41 19](https://github.com/user-attachments/assets/8815e41d-0db1-409b-a43d-e973f2e97057)

But it is still there if access allowed

![Screenshot 2025-06-05 at 11 41 57](https://github.com/user-attachments/assets/9c321a31-f827-44bb-a264-382d2c0d2e5f)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Preview" action for tests, providing a dedicated endpoint to preview tests.
  - Granted "Test Author" roles permission to use the new preview functionality.
- **Chores**
  - Added a configuration file for remote settings management.
- **Migration**
  - Included a migration to manage access control for the new preview feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->