### PR TITLE
fix: Exclude translated into languages from export/clone

### DIFF
--- a/models/classes/class.TestsService.php
+++ b/models/classes/class.TestsService.php
@@ -165,7 +165,8 @@ class taoTests_models_classes_TestsService extends OntologyClassService
         if (!is_null($clone)) {
             $noCloningProperties = [
                 self::PROPERTY_TEST_CONTENT,
-                OntologyRdf::RDF_TYPE
+                OntologyRdf::RDF_TYPE,
+                TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES
             ];
 
             foreach ($clazz->getProperties(true) as $property) {


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/ADF-1969

## What's Changed
- Excluded `TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES` during cloning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test duplication by ensuring translation-related properties are no longer copied when cloning a test instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->