### PR TITLE
fix: while cloning tests, avoid copying translation property

### DIFF
--- a/models/classes/class.TestsService.php
+++ b/models/classes/class.TestsService.php
@@ -165,7 +165,8 @@ class taoTests_models_classes_TestsService extends OntologyClassService
         if (!is_null($clone)) {
             $noCloningProperties = [
                 self::PROPERTY_TEST_CONTENT,
-                OntologyRdf::RDF_TYPE
+                OntologyRdf::RDF_TYPE,
+                TaoOntology::PROPERTY_TRANSLATED_INTO_LANGUAGES
             ];
 
             foreach ($clazz->getProperties(true) as $property) {


### PR DESCRIPTION
## Ticket:

https://oat-sa.atlassian.net/browse/ADF-2063

Avoid populating `http://www.tao.lu/Ontologies/TAO.rdf#TranslatedIntoLanguages` for cloned tests, as copies do not have translations

## How to test
- Follow ACs in ticket