### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,58 +18,58 @@
                         />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="test-class-properties" name="Properties" url="/taoTests/Tests/editClassLabel" group="content" context="class">
+                    <action id="test-class-properties" name="Properties" url="/taoTests/Tests/editClassLabel" group="content" context="class" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class">
+                    <action id="test-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="test-properties"  name="Properties"  url="/taoTests/Tests/editTest" group="content" context="instance">
+                    <action id="test-properties"  name="Properties"  url="/taoTests/Tests/editTest" group="content" context="instance" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-preview" name="Preview" url="/taoTests/Tests/preview" context="instance" group="content" binding="testPreview">
+                    <action id="test-preview" name="Preview" url="/taoTests/Tests/preview" context="instance" group="content" binding="testPreview" weight="9">
                         <icon id="icon-preview"/>
                     </action>
-                    <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor">
+                    <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor" weight="8">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="test-class-new" name="New class" js="subClass" url="/taoTests/Tests/addSubClass" context="resource" group="tree" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="test-delete" name="Delete" url="/taoTests/Tests/delete" context="resource" group="tree" binding="removeNode" weight="-1">
+                    <action id="test-delete" name="Delete" url="/taoTests/Tests/delete" context="resource" group="tree" binding="removeNode" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="test-delete-all" name="Delete" url="/taoTests/Tests/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="-2">
+                    <action id="test-delete-all" name="Delete" url="/taoTests/Tests/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="test-move" name="Move" url="/taoTests/Tests/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="test-import" name="Import" url="/taoTests/TestImport/index" context="resource" group="tree" binding="loadClass" weight="5">
+                    <action id="test-import" name="Import" url="/taoTests/TestImport/index" context="resource" group="tree" binding="loadClass" weight="8">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="test-export" name="Export" url="/taoTests/TestExport/index" context="resource" group="tree"  weight="4">
+                    <action id="test-export" name="Export" url="/taoTests/TestExport/index" context="resource" group="tree"  weight="7">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="test-duplicate" name="Duplicate" js="duplicateNode" url="/taoTests/Tests/cloneInstance" context="instance" group="tree" weight="8">
+                    <action id="test-duplicate" name="Duplicate" js="duplicateNode" url="/taoTests/Tests/cloneInstance" context="instance" group="tree" weight="6">
                         <icon id="icon-duplicate"/>
                     </action>
-                    <action id="test-copy-to" name="Copy To" url="/taoTests/Tests/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
+                    <action id="test-copy-to" name="Copy To" url="/taoTests/Tests/copyInstance" context="instance" group="tree" binding="copyTo" weight="5">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="test-move-to" name="Move To" url="/taoTests/Tests/moveResource" context="instance" group="tree" binding="moveTo" weight="6">
+                    <action id="test-move-to" name="Move To" url="/taoTests/Tests/moveResource" context="instance" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="class-move-to" name="Move To" url="/taoTests/Tests/moveClass" context="class" group="tree" binding="moveTo">
+                    <action id="class-move-to" name="Move To" url="/taoTests/Tests/moveClass" context="class" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="test-move-all" name="Move To" url="/taoTests/Tests/moveAll" context="resource" multiple="true" group="tree" binding="moveTo">
+                    <action id="test-move-all" name="Move To" url="/taoTests/Tests/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="test-new" name="New test" url="/taoTests/Tests/addInstance" context="resource" group="tree" binding="instanciate" weight="9">
+                    <action id="test-new" name="New test" url="/taoTests/Tests/addInstance" context="resource" group="tree" binding="instanciate" weight="1">
                         <icon id="icon-test"/>
                     </action>
-                    <action id="test-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateTest">
+                    <action id="test-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateTest" weight="3">
                         <icon id="icon-replace"/>
                     </action>
                 </actions>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,19 +18,19 @@
                         />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="test-class-properties" name="Properties" url="/taoTests/Tests/editClassLabel" group="content" context="class" weight="10">
+                    <action id="test-class-properties" name="Properties" url="/taoTests/Tests/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
+                    <action id="test-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="8">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="test-properties"  name="Properties"  url="/taoTests/Tests/editTest" group="content" context="instance" weight="10">
+                    <action id="test-properties"  name="Properties"  url="/taoTests/Tests/editTest" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="test-preview" name="Preview" url="/taoTests/Tests/preview" context="instance" group="content" binding="testPreview" weight="9">
+                    <action id="test-preview" name="Preview" url="/taoTests/Tests/preview" context="instance" group="content" binding="testPreview" weight="2">
                         <icon id="icon-preview"/>
                     </action>
-                    <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor" weight="8">
+                    <action id="test-authoring" name="Authoring" url="/taoTests/Tests/authoring" group="content" context="instance" binding="launchEditor" weight="3">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="test-class-new" name="New class" js="subClass" url="/taoTests/Tests/addSubClass" context="resource" group="tree" weight="10">


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted action priority weights across content management and resource operations to optimize menu and interface ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->